### PR TITLE
[COS-3200] getPackageDiffs 빈 객체 반환하도록 수정

### DIFF
--- a/apps/server/src/storage/d1.ts
+++ b/apps/server/src/storage/d1.ts
@@ -692,18 +692,20 @@ export class D1StorageProvider implements StorageProvider {
   private async getPackageDiffs(
     packageId: string,
   ): Promise<PackageHashToBlobInfoMap> {
-    const diffs = await this.db.query.packageDiff.findMany({
-      where: eq(schema.packageDiff.packageId, packageId),
-    });
+    return {};
 
-    const result: PackageHashToBlobInfoMap = {};
-    for (const diff of diffs) {
-      result[diff.sourcePackageHash] = {
-        size: diff.size,
-        url: await this.blob.getBlobUrl(diff.blobPath),
-      };
-    }
-    return result;
+    // const diffs = await this.db.query.packageDiff.findMany({
+    //   where: eq(schema.packageDiff.packageId, packageId),
+    // });
+
+    // const result: PackageHashToBlobInfoMap = {};
+    // for (const diff of diffs) {
+    //   result[diff.sourcePackageHash] = {
+    //     size: diff.size,
+    //     url: await this.blob.getBlobUrl(diff.blobPath),
+    //   };
+    // }
+    // return result;
   }
 
   async commitPackage(


### PR DESCRIPTION
COS-3200

* packageDiff가 빈 테이블
<img width="1360" alt="image" src="https://github.com/user-attachments/assets/dd95c8ba-2a1d-4113-a2a2-3e4442915d30" />


* 24시간 동안 발생하는 쿼리별 개수
<img width="1513" alt="image" src="https://github.com/user-attachments/assets/77fef913-61bb-4a73-a93f-a94c1d0eed08" />

