### PR TITLE
[COS-3202] code push 로컬 cache 구현 및 빈도수 가 높은 쿼리에 caching 로직 추가

### DIFF
--- a/apps/server/src/storage/blob.ts
+++ b/apps/server/src/storage/blob.ts
@@ -5,7 +5,15 @@ import { ErrorCode, isStorageError } from "../types/error";
 import { createStorageError } from "./storage";
 import type { CacheProvider } from "./cache";
 
-export class BlobStorageProvider {
+export interface BlobStorageProvider {
+  addBlob(blobId: string, data: ArrayBuffer, size: number): Promise<string>;
+  getBlobUrl(path: string): Promise<string>;
+  removeBlob(path: string): Promise<void>;
+  moveBlob(sourcePath: string, destinationPath: string): Promise<string>;
+  deletePath(prefix: string): Promise<void>;
+}
+
+export class R2BlobStorageProvider implements BlobStorageProvider {
   private readonly storage: R2Bucket;
   private readonly aws: AwsClient;
   private readonly accountId: string;

--- a/apps/server/src/storage/blob.ts
+++ b/apps/server/src/storage/blob.ts
@@ -13,17 +13,14 @@ export class BlobStorageProvider {
   private readonly cacheKeys = {
     blobUrl: (path: string) => `blob-url:${path}`,
   };
-  private readonly cache: CacheProvider;
 
   constructor(
     private readonly ctx: Context<Env>,
-    private readonly cacheProvider: CacheProvider,
+    private readonly cache: CacheProvider,
   ) {
     this.storage = ctx.env.STORAGE_BUCKET;
     this.accountId = ctx.env.ACCOUNT_ID;
     this.bucketName = ctx.env.R2_BUCKET_NAME;
-    this.cache = cacheProvider;
-
     this.aws = new AwsClient({
       accessKeyId: ctx.env.R2_ACCESS_KEY_ID,
       secretAccessKey: ctx.env.R2_SECRET_ACCESS_KEY,

--- a/apps/server/src/storage/blob.ts
+++ b/apps/server/src/storage/blob.ts
@@ -2,8 +2,8 @@ import { AwsClient } from "aws4fetch";
 import type { Context } from "hono";
 import type { Env } from "../types/env";
 import { ErrorCode, isStorageError } from "../types/error";
-import { createStorageError } from "./storage";
 import type { CacheProvider } from "./cache";
+import { createStorageError } from "./storage";
 
 export interface BlobStorageProvider {
   addBlob(blobId: string, data: ArrayBuffer, size: number): Promise<string>;

--- a/apps/server/src/storage/cache.ts
+++ b/apps/server/src/storage/cache.ts
@@ -1,0 +1,32 @@
+export interface CacheProvider {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string, ttl?: number): Promise<void>;
+  del(key: string): Promise<void>;
+}
+interface CacheItem {
+  value: string;
+  expiresAt?: number;
+}
+
+export class InMemoryCacheProvider implements CacheProvider {
+  private store = new Map<string, CacheItem>();
+
+  async get(key: string): Promise<string | null> {
+    const item = this.store.get(key);
+    if (!item) return null;
+    if (item.expiresAt && item.expiresAt < Date.now()) {
+      this.store.delete(key);
+      return null;
+    }
+    return item.value;
+  }
+
+  async set(key: string, value: string, ttl?: number): Promise<void> {
+    const expiresAt = ttl ? Date.now() + ttl * 1000 : undefined;
+    this.store.set(key, { value, expiresAt });
+  }
+
+  async del(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+}

--- a/apps/server/src/storage/d1.ts
+++ b/apps/server/src/storage/d1.ts
@@ -17,8 +17,8 @@ import type {
 } from "../types/schemas";
 import { generateKey } from "../utils/security";
 import type { BlobStorageProvider } from "./blob";
-import { type StorageProvider, createStorageError } from "./storage";
 import type { CacheProvider } from "./cache";
+import { type StorageProvider, createStorageError } from "./storage";
 
 export class D1StorageProvider implements StorageProvider {
   private readonly db: DrizzleD1Database<typeof schema>;
@@ -578,7 +578,6 @@ export class D1StorageProvider implements StorageProvider {
     if (!deployment) {
       throw createStorageError(ErrorCode.NotFound, "Deployment not found");
     }
-    
 
     const returningDeployment: Deployment = {
       id: deployment.id,

--- a/apps/server/src/storage/d1.ts
+++ b/apps/server/src/storage/d1.ts
@@ -34,7 +34,7 @@ export class D1StorageProvider implements StorageProvider {
     private readonly cache: CacheProvider,
     private readonly blob: BlobStorageProvider,
   ) {
-    this.db = drizzle(ctx.env.DB, { schema });
+    this.db = drizzle(this.ctx.env.DB, { schema });
   }
 
   // Helper methods
@@ -578,7 +578,7 @@ export class D1StorageProvider implements StorageProvider {
     if (!deployment) {
       throw createStorageError(ErrorCode.NotFound, "Deployment not found");
     }
-    this.cache.set(cacheKey, JSON.stringify(deployment), 300);
+    
 
     const returningDeployment: Deployment = {
       id: deployment.id,
@@ -604,6 +604,7 @@ export class D1StorageProvider implements StorageProvider {
       } satisfies Package;
     }
 
+    this.cache.set(cacheKey, JSON.stringify(returningDeployment), 300);
     return returningDeployment;
   }
 

--- a/apps/server/src/storage/d1.ts
+++ b/apps/server/src/storage/d1.ts
@@ -16,14 +16,12 @@ import type {
   PackageHashToBlobInfoMap,
 } from "../types/schemas";
 import { generateKey } from "../utils/security";
-import { BlobStorageProvider } from "./blob";
+import type { BlobStorageProvider } from "./blob";
 import { type StorageProvider, createStorageError } from "./storage";
 import type { CacheProvider } from "./cache";
 
 export class D1StorageProvider implements StorageProvider {
   private readonly db: DrizzleD1Database<typeof schema>;
-  private readonly blob: BlobStorageProvider;
-  private readonly cache: CacheProvider;
   private readonly cacheKeys = {
     package: (accountId: string, appId: string, deploymentId: string) =>
       `package:${accountId}:${appId}:${deploymentId}`,
@@ -33,11 +31,10 @@ export class D1StorageProvider implements StorageProvider {
 
   constructor(
     private readonly ctx: Context<Env>,
-    cacheProvider: CacheProvider,
+    private readonly cache: CacheProvider,
+    private readonly blob: BlobStorageProvider,
   ) {
     this.db = drizzle(ctx.env.DB, { schema });
-    this.cache = cacheProvider;
-    this.blob = new BlobStorageProvider(ctx, cacheProvider);
   }
 
   // Helper methods

--- a/apps/server/src/storage/factory.ts
+++ b/apps/server/src/storage/factory.ts
@@ -2,15 +2,24 @@ import type { Context } from "hono";
 import type { Env } from "../types/env";
 import { D1StorageProvider } from "./d1";
 import type { StorageProvider } from "./storage";
+import { InMemoryCacheProvider, type CacheProvider } from "./cache";
 
 let storageInstance: StorageProvider | null = null;
 let lastContext: Context<Env> | null = null;
+let cacheInstance: CacheProvider | null = null;
 
 export function getStorageProvider(ctx: Context<Env>): StorageProvider {
   // If context changed or no instance exists, create new instance
   if (!storageInstance || ctx !== lastContext) {
-    storageInstance = new D1StorageProvider(ctx);
+    storageInstance = new D1StorageProvider(ctx, getCacheProvider(ctx));
     lastContext = ctx;
   }
   return storageInstance;
+}
+
+export function getCacheProvider(ctx: Context<Env>): CacheProvider {
+  if (!cacheInstance) {
+    cacheInstance = new InMemoryCacheProvider();
+  }
+  return cacheInstance;
 }

--- a/apps/server/src/storage/factory.ts
+++ b/apps/server/src/storage/factory.ts
@@ -3,15 +3,19 @@ import type { Env } from "../types/env";
 import { D1StorageProvider } from "./d1";
 import type { StorageProvider } from "./storage";
 import { InMemoryCacheProvider, type CacheProvider } from "./cache";
+import { BlobStorageProvider } from "./blob";
 
 let storageInstance: StorageProvider | null = null;
 let lastContext: Context<Env> | null = null;
 let cacheInstance: CacheProvider | null = null;
+let blobInstance: BlobStorageProvider | null = null;
 
 export function getStorageProvider(ctx: Context<Env>): StorageProvider {
   // If context changed or no instance exists, create new instance
   if (!storageInstance || ctx !== lastContext) {
-    storageInstance = new D1StorageProvider(ctx, getCacheProvider(ctx));
+    const cache = getCacheProvider(ctx);
+    const blob = getBlobProvider(ctx, cache);
+    storageInstance = new D1StorageProvider(ctx, cache, blob);
     lastContext = ctx;
   }
   return storageInstance;
@@ -22,4 +26,14 @@ export function getCacheProvider(ctx: Context<Env>): CacheProvider {
     cacheInstance = new InMemoryCacheProvider();
   }
   return cacheInstance;
+}
+
+export function getBlobProvider(
+  ctx: Context<Env>,
+  cache: CacheProvider,
+): BlobStorageProvider {
+  if (!blobInstance || ctx !== lastContext) {
+    blobInstance = new BlobStorageProvider(ctx, cache);
+  }
+  return blobInstance;
 }

--- a/apps/server/src/storage/factory.ts
+++ b/apps/server/src/storage/factory.ts
@@ -1,10 +1,10 @@
 import type { Context } from "hono";
 import type { Env } from "../types/env";
-import { D1StorageProvider } from "./d1";
-import type { StorageProvider } from "./storage";
-import { InMemoryCacheProvider, type CacheProvider } from "./cache";
 import type { BlobStorageProvider } from "./blob";
 import { R2BlobStorageProvider } from "./blob";
+import { type CacheProvider, InMemoryCacheProvider } from "./cache";
+import { D1StorageProvider } from "./d1";
+import type { StorageProvider } from "./storage";
 
 let storageInstance: StorageProvider | null = null;
 let lastContext: Context<Env> | null = null;

--- a/apps/server/src/storage/factory.ts
+++ b/apps/server/src/storage/factory.ts
@@ -3,7 +3,8 @@ import type { Env } from "../types/env";
 import { D1StorageProvider } from "./d1";
 import type { StorageProvider } from "./storage";
 import { InMemoryCacheProvider, type CacheProvider } from "./cache";
-import { BlobStorageProvider } from "./blob";
+import type { BlobStorageProvider } from "./blob";
+import { R2BlobStorageProvider } from "./blob";
 
 let storageInstance: StorageProvider | null = null;
 let lastContext: Context<Env> | null = null;
@@ -33,7 +34,7 @@ export function getBlobProvider(
   cache: CacheProvider,
 ): BlobStorageProvider {
   if (!blobInstance || ctx !== lastContext) {
-    blobInstance = new BlobStorageProvider(ctx, cache);
+    blobInstance = new R2BlobStorageProvider(ctx, cache);
   }
   return blobInstance;
 }

--- a/apps/server/test/storage/cache.test.ts
+++ b/apps/server/test/storage/cache.test.ts
@@ -1,21 +1,26 @@
 import { InMemoryCacheProvider } from "../../src/storage/cache";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
+import { vi } from "vitest";
+
 describe("Cache", () => {
+  let cache: InMemoryCacheProvider;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cache = new InMemoryCacheProvider();
+  });
+
   it("should be able to set and get a value", async () => {
-    const cache = new InMemoryCacheProvider();
     await cache.set("test", "test");
     expect(await cache.get("test")).toBe("test");
   });
 
   it("should be able to delete a value", async () => {
-    const cache = new InMemoryCacheProvider();
     await cache.set("test", "test");
     await cache.del("test");
     expect(await cache.get("test")).toBeNull();
   });
 
   it("should be able to set a value with an expiration time", async () => {
-    const cache = new InMemoryCacheProvider();
     await cache.set("test", "test", 1);
     expect(await cache.get("test")).toBe("test");
     await new Promise((resolve) => setTimeout(resolve, 1500));
@@ -23,14 +28,12 @@ describe("Cache", () => {
   });
 
   it("should be inable to get a value that has expired", async () => {
-    const cache = new InMemoryCacheProvider();
-    await cache.set("test", "test", 0.01);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await cache.set("test", "test", 1);
+    await new Promise((resolve) => setTimeout(resolve, 1500));
     expect(await cache.get("test")).toBeNull();
   });
 
   it("should be inable to get a value deleted", async () => {
-    const cache = new InMemoryCacheProvider();
     await cache.set("test", "test");
     await cache.del("test");
     expect(await cache.get("test")).toBeNull();

--- a/apps/server/test/storage/cache.test.ts
+++ b/apps/server/test/storage/cache.test.ts
@@ -1,0 +1,38 @@
+import { InMemoryCacheProvider } from "../../src/storage/cache";
+import { describe, it, expect } from "vitest";
+describe("Cache", () => {
+  it("should be able to set and get a value", async () => {
+    const cache = new InMemoryCacheProvider();
+    await cache.set("test", "test");
+    expect(await cache.get("test")).toBe("test");
+  });
+
+  it("should be able to delete a value", async () => {
+    const cache = new InMemoryCacheProvider();
+    await cache.set("test", "test");
+    await cache.del("test");
+    expect(await cache.get("test")).toBeNull();
+  });
+
+  it("should be able to set a value with an expiration time", async () => {
+    const cache = new InMemoryCacheProvider();
+    await cache.set("test", "test", 1);
+    expect(await cache.get("test")).toBe("test");
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+    expect(await cache.get("test")).toBeNull();
+  });
+
+  it("should be inable to get a value that has expired", async () => {
+    const cache = new InMemoryCacheProvider();
+    await cache.set("test", "test", 0.01);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(await cache.get("test")).toBeNull();
+  });
+
+  it("should be inable to get a value deleted", async () => {
+    const cache = new InMemoryCacheProvider();
+    await cache.set("test", "test");
+    await cache.del("test");
+    expect(await cache.get("test")).toBeNull();
+  });
+});

--- a/apps/server/test/storage/d1.test.ts
+++ b/apps/server/test/storage/d1.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { D1StorageProvider } from "../../src/storage/d1";
+import { InMemoryCacheProvider } from "../../src/storage/cache";
+import type { Context } from "hono";
+import type { Env } from "../../src/types/env";
+import * as schema from "../../src/db/schema";
+import { cleanupDatabase, getTestDb } from "../utils/db";
+import {
+  createTestAccount,
+  createTestApp,
+  createTestDeployment,
+  createTestPackage,
+} from "../utils/fixtures";
+import { env } from "cloudflare:test";
+import { MockBlobStorageProvider } from "./mock-blob";
+
+describe("D1StorageProvider Cache", () => {
+  let storage: D1StorageProvider;
+  let mockCtx: Context<Env>;
+  let mockCache: InMemoryCacheProvider;
+  let mockBlob: MockBlobStorageProvider;
+  let db: ReturnType<typeof getTestDb>;
+  let account: ReturnType<typeof createTestAccount>;
+  let app: ReturnType<typeof createTestApp>;
+
+  beforeEach(async () => {
+    db = getTestDb();
+    await cleanupDatabase();
+
+    // Create test data
+    account = createTestAccount();
+    await db.insert(schema.account).values(account);
+
+    app = createTestApp();
+    await db.insert(schema.app).values(app);
+
+    // Add owner collaborator
+    await db.insert(schema.collaborator).values({
+      appId: app.id,
+      accountId: account.id,
+      permission: "Owner",
+    });
+
+    mockCtx = {
+      env: {
+        DB: env.DB,
+      },
+    } as unknown as Context<Env>;
+
+    mockCache = new InMemoryCacheProvider();
+    mockBlob = new MockBlobStorageProvider(mockCtx, mockCache);
+    storage = new D1StorageProvider(mockCtx, mockCache, mockBlob);
+    console.log(typeof mockCtx.env.DB.prepare);
+  });
+
+  afterEach(async () => {
+    await cleanupDatabase();
+  });
+
+  it("should cache and return deployment data", async () => {
+    const deployment = createTestDeployment(app.id);
+    await db.insert(schema.deployment).values(deployment);
+    const packageHistory = createTestPackage(deployment.id);
+    await db.insert(schema.packages).values(packageHistory);
+
+    const result = await storage.getDeployment(
+      account.id,
+      app.id,
+      deployment.id,
+    );
+
+    expect(result.id).toBe(deployment.id);
+    expect(
+      await mockCache.get(
+        `deployment:${account.id}:${app.id}:${deployment.id}`,
+      ),
+    ).toBe(JSON.stringify(result));
+  });
+
+  it("should cache and return package history data", async () => {
+    const deployment = createTestDeployment(app.id);
+    await db.insert(schema.deployment).values(deployment);
+    const packageHistory = createTestPackage(deployment.id);
+    await db.insert(schema.packages).values(packageHistory);
+
+    const result = await storage.getPackageHistory(
+      account.id,
+      app.id,
+      deployment.id,
+    );
+
+    expect(result.length).toBe(1);
+    expect(
+      await mockCache.get(`package:${account.id}:${app.id}:${deployment.id}`),
+    ).toBe(JSON.stringify(result));
+  });
+
+  it("should invalidate cache when committing new package", async () => {
+    const deployment = createTestDeployment(app.id);
+    await db.insert(schema.deployment).values(deployment);
+    const packageHistory = createTestPackage(deployment.id);
+    await db.insert(schema.packages).values(packageHistory);
+
+    // First get to populate cache
+    await storage.getPackageHistory(account.id, app.id, deployment.id);
+    expect(
+      await mockCache.get(`package:${account.id}:${app.id}:${deployment.id}`),
+    ).toBeDefined();
+
+    // Create test blob data
+    const blobId = "test-blob-id";
+    const blobData = new ArrayBuffer(1024);
+    const blobUrl = await mockBlob.addBlob(blobId, blobData, 1024);
+
+    // Commit new package
+    const newPackage = {
+      appVersion: "1.0.0",
+      description: "Test package",
+      isDisabled: false,
+      isMandatory: false,
+      rollout: 100,
+      size: 1024,
+      packageHash: "test-hash",
+      uploadTime: Date.now(),
+      blobUrl,
+      manifestBlobUrl: "",
+      diffPackageMap: {},
+    };
+
+    await storage.commitPackage(account.id, app.id, deployment.id, newPackage);
+
+    // Cache should be invalidated
+    expect(
+      await mockCache.get(`package:${account.id}:${app.id}:${deployment.id}`),
+    ).toBeNull();
+  });
+
+  it("should cache and return package history data from deployment key", async () => {
+    const deployment = createTestDeployment(app.id);
+    await db.insert(schema.deployment).values(deployment);
+    const packageHistory = createTestPackage(deployment.id);
+    await db.insert(schema.packages).values(packageHistory);
+
+    // First get to populate cache
+    await storage.getPackageHistory(account.id, app.id, deployment.id);
+
+    const result = await storage.getPackageHistoryFromDeploymentKey(
+      deployment.key,
+    );
+
+    expect(result.length).toBe(1);
+    expect(
+      await mockCache.get(`package:${account.id}:${app.id}:${deployment.id}`),
+    ).toBe(JSON.stringify(result));
+  });
+});

--- a/apps/server/test/storage/mock-blob.ts
+++ b/apps/server/test/storage/mock-blob.ts
@@ -1,0 +1,75 @@
+import { Context } from "hono";
+import type { BlobStorageProvider } from "../../src/storage/blob";
+import type { CacheProvider } from "../../src/storage/cache";
+import { Env } from "../../src/types/env";
+
+export class MockBlobStorageProvider implements BlobStorageProvider {
+  private readonly store = new Map<string, ArrayBuffer>();
+  private readonly urls = new Map<string, string>();
+
+  constructor(
+    private readonly ctx: Context<Env>,
+    private readonly cache: CacheProvider,
+  ) {}
+
+  async addBlob(
+    blobId: string,
+    data: ArrayBuffer,
+    size: number,
+  ): Promise<string> {
+    this.store.set(blobId, data);
+
+    const url = `https://mock-storage.com/${blobId}`;
+    this.urls.set(blobId, url);
+    return url;
+  }
+
+  async getBlobUrl(path: string): Promise<string> {
+    const url = this.urls.get(path) || `https://mock-storage.com/${path}`;
+    this.urls.set(path, url);
+    return url;
+  }
+
+  async removeBlob(path: string): Promise<void> {
+    this.store.delete(path);
+    this.urls.delete(path);
+  }
+
+  async moveBlob(sourceUrl: string, targetPath: string): Promise<string> {
+    // Extract blobId from URL or path
+    const sourceBlobId = sourceUrl.startsWith("https://")
+      ? sourceUrl.split("/").pop()
+      : sourceUrl;
+    if (!sourceBlobId) {
+      throw new Error(`Invalid source URL: ${sourceUrl}`);
+    }
+
+    const data = this.store.get(sourceBlobId);
+    if (!data) {
+      throw new Error(`Blob not found: ${sourceBlobId}`);
+    }
+
+    const targetBlobId = targetPath.split("/").pop();
+    if (!targetBlobId) {
+      throw new Error(`Invalid target path: ${targetPath}`);
+    }
+
+    console.log("targetBlobId", targetBlobId);
+
+    this.store.set(targetBlobId, data);
+    this.store.delete(sourceBlobId);
+
+    const url = `https://mock-storage.com/${targetBlobId}`;
+    this.urls.set(targetBlobId, url);
+    return url;
+  }
+
+  async deletePath(prefix: string): Promise<void> {
+    for (const [key] of this.store) {
+      if (key.startsWith(prefix)) {
+        this.store.delete(key);
+        this.urls.delete(key);
+      }
+    }
+  }
+} 


### PR DESCRIPTION
COS-3202
* InMemoryCacheProvider를 singletone으로 추가했습니다.
* getPackageHistory,  getDeployment 에 캐싱을 추가했습니다.
* 관련된 테스트 코드를 작성했습니다.