### PR TITLE
[FE-62] feat: History 서버 페이지네이션 + 테이블→카드 전환

### DIFF
--- a/apps/server/src/routes/management.ts
+++ b/apps/server/src/routes/management.ts
@@ -524,6 +524,10 @@ const routes = {
           appName: z.string(),
           deploymentName: z.string(),
         }),
+        query: z.object({
+          page: z.coerce.number().int().min(1).default(1),
+          pageSize: z.coerce.number().int().min(1).max(100).default(20),
+        }),
       },
       responses: {
         200: {
@@ -1624,6 +1628,7 @@ router.openapi(routes.deployments.history, async (c) => {
   const storage = getStorageProvider(c);
   const accountId = c.var.auth.accountId;
   const { appName, deploymentName } = c.req.valid("param");
+  const { page, pageSize } = c.req.valid("query");
 
   const app = await storage.getApp(accountId, { appName });
   if (!app) {
@@ -1643,13 +1648,22 @@ router.openapi(routes.deployments.history, async (c) => {
     });
   }
 
-  const history = await storage.getPackageHistory(
+  // getPackageHistory는 uploadTime 오름차순 전체 배열을 반환한다(OTA·롤백·중복검사 등이
+  // 공유하는 계약이므로 그대로 둔다). 페이지네이션은 이 핸들러에서만 최신순으로 뒤집어
+  // 슬라이스한다. 파라미터가 없으면 page=1/pageSize=20 → 최신 페이지가 기본.
+  const fullHistory = await storage.getPackageHistory(
     accountId,
     app.id,
     deployment.id,
   );
+  const totalCount = fullHistory.length;
+  const start = (page - 1) * pageSize;
+  const history = fullHistory
+    .slice()
+    .reverse()
+    .slice(start, start + pageSize);
 
-  return c.json({ history });
+  return c.json({ history, totalCount, page, pageSize });
 });
 
 export { router as managementRouter };

--- a/apps/web/src/pages/history/HistoryPage.tsx
+++ b/apps/web/src/pages/history/HistoryPage.tsx
@@ -1,28 +1,28 @@
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { api } from "@/lib/api";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Check, RefreshCw, X } from "lucide-react";
+import { ChevronLeft, ChevronRight, RefreshCw } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 
+const PAGE_SIZE = 20;
+
 // history 라우트는 서버 OpenAPI 응답 스키마가 비어 있어 api-client가 void로 생성한다.
-// 실제 응답은 { history: Package[] } 이므로 여기서 형태를 명시한다.
+// 실제 응답은 { history, totalCount, page, pageSize } 이므로 여기서 형태를 명시한다.
 interface ReleaseHistoryItem {
   label?: string;
   appVersion?: string;
@@ -36,6 +36,9 @@ interface ReleaseHistoryItem {
 }
 interface HistoryResponse {
   history: ReleaseHistoryItem[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
 }
 interface MetricEntry {
   active?: number;
@@ -44,19 +47,6 @@ interface MetricEntry {
   failed?: number;
 }
 type MergedItem = ReleaseHistoryItem & MetricEntry;
-
-function formatBytes(bytes?: number): string {
-  if (bytes == null || !Number.isFinite(bytes) || bytes < 0) return "-";
-  if (bytes < 1024) return `${bytes} B`;
-  const units = ["KB", "MB", "GB", "TB"] as const;
-  let value = bytes / 1024;
-  let unitIndex = 0;
-  while (value >= 1024 && unitIndex < units.length - 1) {
-    value /= 1024;
-    unitIndex += 1;
-  }
-  return `${value.toFixed(1)} ${units[unitIndex]}`;
-}
 
 function formatTime(ts?: number): string {
   if (ts == null || !Number.isFinite(ts) || ts <= 0) return "-";
@@ -74,6 +64,7 @@ export const HistoryPage = () => {
   const queryClient = useQueryClient();
   const [appName, setAppName] = useState<string>("");
   const [deploymentName, setDeploymentName] = useState<string>("");
+  const [page, setPage] = useState<number>(1);
 
   const { data: appsData } = useQuery({
     queryKey: ["apps"],
@@ -103,6 +94,11 @@ export const HistoryPage = () => {
     setDeploymentName(names.includes("Production") ? "Production" : names[0]);
   }, [deployments, deploymentName]);
 
+  // 앱·배포를 바꾸면 첫 페이지로 되돌린다.
+  useEffect(() => {
+    setPage(1);
+  }, [appName, deploymentName]);
+
   const historyEnabled = !!appName && !!deploymentName;
 
   const {
@@ -111,11 +107,13 @@ export const HistoryPage = () => {
     isError: isHistoryError,
     isFetching,
   } = useQuery({
-    queryKey: ["history", appName, deploymentName],
+    queryKey: ["history", appName, deploymentName, page],
     queryFn: async () => {
       const response = await api.appsAppNameDeploymentsDeploymentNameHistoryGet(
         appName,
         deploymentName,
+        page,
+        PAGE_SIZE,
       );
       // 위 주석 참조: 서버 실제 응답 형태로 해석
       return response.data as unknown as HistoryResponse;
@@ -135,17 +133,18 @@ export const HistoryPage = () => {
     enabled: historyEnabled,
   });
 
+  // 서버가 최신순 페이지를 내려주므로 정렬은 서버에 맡기고 지표만 병합한다.
   const rows: MergedItem[] = useMemo(() => {
     const history = historyData?.history ?? [];
     const metrics = (metricsData?.metrics ?? {}) as Record<string, MetricEntry>;
-    return history
-      .slice()
-      .sort((a, b) => (b.uploadTime ?? 0) - (a.uploadTime ?? 0))
-      .map((item) => ({
-        ...item,
-        ...(item.label ? metrics[item.label] : {}),
-      }));
+    return history.map((item) => ({
+      ...item,
+      ...(item.label ? metrics[item.label] : {}),
+    }));
   }, [historyData, metricsData]);
+
+  const totalCount = historyData?.totalCount ?? 0;
+  const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE));
 
   const disableMutation = useMutation({
     mutationFn: async ({
@@ -248,84 +247,93 @@ export const HistoryPage = () => {
         </Button>
       </div>
 
-      <div className="rounded-lg border">
-        {isHistoryLoading ? (
-          <div className="p-8 text-center text-sm text-muted-foreground">
-            데이터를 불러오는 중입니다...
-          </div>
-        ) : isHistoryError ? (
-          <div className="p-8 text-center text-sm text-destructive">
-            이력을 불러오지 못했습니다. 새로고침하거나 다시 로그인해 주세요.
-          </div>
-        ) : rows.length === 0 ? (
-          <div className="p-8 text-center text-sm text-muted-foreground">
-            릴리즈 이력이 없습니다.
-          </div>
-        ) : (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Label</TableHead>
-                <TableHead>App Version</TableHead>
-                <TableHead className="text-center">Mandatory</TableHead>
-                <TableHead className="text-center">Disabled</TableHead>
-                <TableHead>Description</TableHead>
-                <TableHead className="text-center">Installed</TableHead>
-                <TableHead className="text-center">Active</TableHead>
-                <TableHead className="text-center">Size</TableHead>
-                <TableHead>Uploaded</TableHead>
-                <TableHead className="text-right">Action</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {rows.map((item) => (
-                <TableRow key={item.label}>
-                  <TableCell className="font-medium">{item.label}</TableCell>
-                  <TableCell>{item.appVersion}</TableCell>
-                  <TableCell className="text-center">
-                    {item.isMandatory ? (
-                      <Check className="mx-auto h-4 w-4 text-emerald-600" />
-                    ) : (
-                      <X className="mx-auto h-4 w-4 text-muted-foreground" />
-                    )}
-                  </TableCell>
-                  <TableCell className="text-center">
-                    {item.isDisabled ? (
-                      <Badge variant="destructive">Disabled</Badge>
-                    ) : (
-                      <Badge variant="secondary">Active</Badge>
-                    )}
-                  </TableCell>
-                  <TableCell className="max-w-[240px] truncate">
+      {isHistoryLoading ? (
+        <div className="rounded-lg border p-8 text-center text-sm text-muted-foreground">
+          데이터를 불러오는 중입니다...
+        </div>
+      ) : isHistoryError ? (
+        <div className="rounded-lg border p-8 text-center text-sm text-destructive">
+          이력을 불러오지 못했습니다. 새로고침하거나 다시 로그인해 주세요.
+        </div>
+      ) : rows.length === 0 ? (
+        <div className="rounded-lg border p-8 text-center text-sm text-muted-foreground">
+          릴리즈 이력이 없습니다.
+        </div>
+      ) : (
+        <>
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            {rows.map((item) => (
+              <Card
+                key={item.label}
+                className={item.isDisabled ? "opacity-60" : undefined}
+              >
+                <CardHeader className="pb-3">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <CardTitle className="text-base">{item.label}</CardTitle>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        v{item.appVersion ?? "-"} · {formatTime(item.uploadTime)}
+                      </p>
+                    </div>
+                    <div className="flex shrink-0 items-center gap-1.5">
+                      {item.isMandatory && (
+                        <Badge variant="outline">Mandatory</Badge>
+                      )}
+                      {item.isDisabled ? (
+                        <Badge variant="destructive">Disabled</Badge>
+                      ) : (
+                        <Badge variant="secondary">Active</Badge>
+                      )}
+                    </div>
+                  </div>
+                  <p className="mt-2 min-h-[1.25rem] truncate text-sm text-muted-foreground">
                     {item.description || "-"}
-                  </TableCell>
-                  <TableCell className="text-center">
-                    {item.installed ?? 0}
-                  </TableCell>
-                  <TableCell className="text-center">
-                    {item.active ?? 0}
-                  </TableCell>
-                  <TableCell className="text-center">
-                    {formatBytes(item.size)}
-                  </TableCell>
-                  <TableCell>{formatTime(item.uploadTime)}</TableCell>
-                  <TableCell className="text-right">
-                    <Button
-                      variant={item.isDisabled ? "outline" : "destructive"}
-                      size="sm"
-                      className="min-w-[84px]"
-                      disabled={disableMutation.isPending}
-                      onClick={() => onToggleDisable(item)}
-                    >
-                      {item.isDisabled ? "Enable" : "Disable"}
-                    </Button>
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        )}
-      </div>
+                  </p>
+                </CardHeader>
+                <CardContent className="flex items-center justify-between gap-2 pb-4">
+                  <span className="text-sm text-muted-foreground">
+                    설치 {item.installed ?? 0} · 활성 {item.active ?? 0}
+                  </span>
+                  <Button
+                    variant={item.isDisabled ? "outline" : "destructive"}
+                    size="sm"
+                    disabled={disableMutation.isPending}
+                    onClick={() => onToggleDisable(item)}
+                  >
+                    {item.isDisabled ? "Enable" : "Disable"}
+                  </Button>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+
+          <div className="flex items-center justify-between">
+            <p className="text-sm text-muted-foreground">
+              전체 {totalCount}개 · {page}/{totalPages} 페이지
+            </p>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page <= 1 || isFetching}
+                onClick={() => setPage((prev) => Math.max(1, prev - 1))}
+              >
+                <ChevronLeft className="mr-1 h-4 w-4" />
+                이전
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page >= totalPages || isFetching}
+                onClick={() => setPage((prev) => prev + 1)}
+              >
+                다음
+                <ChevronRight className="ml-1 h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/packages/api-client/src/api.ts
+++ b/packages/api-client/src/api.ts
@@ -1684,10 +1684,12 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
          * Get deployment history
          * @param {string} appName 
          * @param {string} deploymentName 
+         * @param {number} [page] 
+         * @param {number} [pageSize] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        appsAppNameDeploymentsDeploymentNameHistoryGet: async (appName: string, deploymentName: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        appsAppNameDeploymentsDeploymentNameHistoryGet: async (appName: string, deploymentName: string, page?: number, pageSize?: number, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'appName' is not null or undefined
             assertParamExists('appsAppNameDeploymentsDeploymentNameHistoryGet', 'appName', appName)
             // verify required parameter 'deploymentName' is not null or undefined
@@ -1705,6 +1707,14 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
             const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
+
+            if (page !== undefined) {
+                localVarQueryParameter['page'] = page;
+            }
+
+            if (pageSize !== undefined) {
+                localVarQueryParameter['pageSize'] = pageSize;
+            }
 
 
     
@@ -2732,11 +2742,13 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * Get deployment history
          * @param {string} appName 
          * @param {string} deploymentName 
+         * @param {number} [page] 
+         * @param {number} [pageSize] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async appsAppNameDeploymentsDeploymentNameHistoryGet(appName: string, deploymentName: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.appsAppNameDeploymentsDeploymentNameHistoryGet(appName, deploymentName, options);
+        async appsAppNameDeploymentsDeploymentNameHistoryGet(appName: string, deploymentName: string, page?: number, pageSize?: number, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.appsAppNameDeploymentsDeploymentNameHistoryGet(appName, deploymentName, page, pageSize, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.appsAppNameDeploymentsDeploymentNameHistoryGet']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
@@ -3154,11 +3166,13 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          * Get deployment history
          * @param {string} appName 
          * @param {string} deploymentName 
+         * @param {number} [page] 
+         * @param {number} [pageSize] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        appsAppNameDeploymentsDeploymentNameHistoryGet(appName: string, deploymentName: string, options?: RawAxiosRequestConfig): AxiosPromise<void> {
-            return localVarFp.appsAppNameDeploymentsDeploymentNameHistoryGet(appName, deploymentName, options).then((request) => request(axios, basePath));
+        appsAppNameDeploymentsDeploymentNameHistoryGet(appName: string, deploymentName: string, page?: number, pageSize?: number, options?: RawAxiosRequestConfig): AxiosPromise<void> {
+            return localVarFp.appsAppNameDeploymentsDeploymentNameHistoryGet(appName, deploymentName, page, pageSize, options).then((request) => request(axios, basePath));
         },
         /**
          * Get deployment metrics
@@ -3506,11 +3520,13 @@ export interface DefaultApiInterface {
      * Get deployment history
      * @param {string} appName 
      * @param {string} deploymentName 
+     * @param {number} [page] 
+     * @param {number} [pageSize] 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof DefaultApiInterface
      */
-    appsAppNameDeploymentsDeploymentNameHistoryGet(appName: string, deploymentName: string, options?: RawAxiosRequestConfig): AxiosPromise<void>;
+    appsAppNameDeploymentsDeploymentNameHistoryGet(appName: string, deploymentName: string, page?: number, pageSize?: number, options?: RawAxiosRequestConfig): AxiosPromise<void>;
 
     /**
      * Get deployment metrics
@@ -3882,12 +3898,14 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
      * Get deployment history
      * @param {string} appName 
      * @param {string} deploymentName 
+     * @param {number} [page] 
+     * @param {number} [pageSize] 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof DefaultApi
      */
-    public appsAppNameDeploymentsDeploymentNameHistoryGet(appName: string, deploymentName: string, options?: RawAxiosRequestConfig) {
-        return DefaultApiFp(this.configuration).appsAppNameDeploymentsDeploymentNameHistoryGet(appName, deploymentName, options).then((request) => request(this.axios, this.basePath));
+    public appsAppNameDeploymentsDeploymentNameHistoryGet(appName: string, deploymentName: string, page?: number, pageSize?: number, options?: RawAxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).appsAppNameDeploymentsDeploymentNameHistoryGet(appName, deploymentName, page, pageSize, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**


### PR DESCRIPTION
# 요약

CodePush 릴리즈 History를 **서버 사이드 페이지네이션**으로 전환하고, 웹 대시보드 목록을 **테이블 → 카드**로 개편합니다. [FE-62](https://yplabs.atlassian.net/browse/FE-62)

## 변경 사항

### server (`apps/server/src/routes/management.ts`)
- `/history` 라우트에 `page`/`pageSize` 쿼리 스키마 추가 (기본 `1`/`20`, `pageSize` 최대 100).
- 핸들러에서만 최신순으로 뒤집어 페이지 슬라이스. 응답에 `totalCount`/`page`/`pageSize` 추가.
- **`getPackageHistory`(storage)는 미변경** — 오름차순 전체 배열 계약을 OTA update-check·롤백·중복검사·diff가 공유하므로 절대 손대지 않고, 슬라이스는 `/history` 핸들러에 국한.
- 파라미터가 없으면 **최신 페이지가 기본** 반환.

### api-client (`packages/api-client/src/api.ts`)
- `/docs` 기반 재생성으로 history 메서드에 `page?`/`pageSize?` 파라미터 반영 (+ `fix-colon-paths` 정규화).

### web (`apps/web/src/pages/history/HistoryPage.tsx`)
- 릴리즈 히스토리 **테이블 → 카드 그리드** 전환.
- 이전/다음 **페이지네이션 컨트롤** (`전체 N개 · x/y 페이지`), 앱·배포 전환 시 1페이지로 리셋.

## 테스트

- 로컬 서버(prod DB 스냅샷 사본)로 검증: 파라미터 없음=최신 20개, `page=2`, `pageSize` 변경, 마지막 페이지 모두 정확.
- `apps/server`: `tsc` EXIT=0, `biome check`(error 레벨) 통과, **vitest 115개 전부 통과**.
- `apps/web`: `tsc` EXIT=0.

## 참고

- 기존 소비자(CLI `deployment history` 등)는 파라미터 미전달 시 **최신 20개**만 받게 됩니다(요구사항 "default 최신"). 전량이 필요하면 `pageSize`로 조정.
- 자동 배포 워크플로우 없음 — 머지가 prod 배포를 트리거하지 않으며, 배포는 별도 `wrangler publish` 수동 단계입니다.

[FE-62]: https://yplabs.atlassian.net/browse/FE-62?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ