### PR TITLE
[FE-63] fix: 릴리즈 재활성화(enable) 무시 + 히스토리 캐시 무효화 누락

### DIFF
--- a/apps/server/src/routes/management.ts
+++ b/apps/server/src/routes/management.ts
@@ -1328,11 +1328,11 @@ router.openapi(routes.deployments.release.update, async (c) => {
   if (packageInfo.description) {
     updatedRelease.description = packageInfo.description;
   }
-  if (packageInfo.isDisabled) {
+  if (packageInfo.isDisabled != null) {
     updatedRelease.isDisabled = packageInfo.isDisabled;
   }
 
-  await storage.updatePackage(updatedRelease);
+  await storage.updatePackage(updatedRelease, deployment.id);
   return c.json({ release: updatedRelease });
 });
 

--- a/apps/server/src/storage/d1.ts
+++ b/apps/server/src/storage/d1.ts
@@ -23,8 +23,10 @@ import { type StorageProvider, createStorageError } from "./storage";
 export class D1StorageProvider implements StorageProvider {
   private readonly db: DrizzleD1Database<typeof schema>;
   private readonly cacheKeys = {
-    package: (accountId: string, appId: string, deploymentId: string) =>
-      `package:${accountId}:${appId}:${deploymentId}`,
+    // 패키지 히스토리는 deploymentId만으로 결정된다(getPackageHistory 쿼리가 accountId/appId를
+    // 쓰지 않음). accountId/appId를 키에 넣으면 같은 배포가 호출부별로 다중 캐시되어
+    // 무효화가 누락되므로 deploymentId 단일 키로 통일한다.
+    package: (deploymentId: string) => `package:${deploymentId}`,
     deployment: (accountId: string, appId: string, deploymentId: string) =>
       `deployment:${accountId}:${appId}:${deploymentId}`,
   };
@@ -778,7 +780,7 @@ export class D1StorageProvider implements StorageProvider {
       uploadTime: pkg.uploadTime,
     });
 
-    const cacheKey = this.cacheKeys.package(accountId, appId, deploymentId);
+    const cacheKey = this.cacheKeys.package(deploymentId);
     await this.cache.del(cacheKey);
 
     return {
@@ -790,7 +792,7 @@ export class D1StorageProvider implements StorageProvider {
     };
   }
 
-  async updatePackage(pkg: Package): Promise<Package> {
+  async updatePackage(pkg: Package, deploymentId: string): Promise<Package> {
     await this.db
       .update(schema.packages)
       .set({
@@ -799,6 +801,9 @@ export class D1StorageProvider implements StorageProvider {
         isDisabled: pkg.isDisabled,
       })
       .where(eq(schema.packages.packageHash, pkg.packageHash));
+    // isDisabled 등 상태 변경 후 히스토리 캐시를 무효화한다. 그렇지 않으면 getPackageHistory가
+    // 최대 5분간 stale 값을 반환해 enable/disable 반영이 지연되고 OTA 업데이트 결정도 어긋난다.
+    await this.cache.del(this.cacheKeys.package(deploymentId));
     return pkg;
   }
 
@@ -807,7 +812,7 @@ export class D1StorageProvider implements StorageProvider {
     appId: string,
     deploymentId: string,
   ): Promise<Package[]> {
-    const cacheKey = this.cacheKeys.package(accountId, appId, deploymentId);
+    const cacheKey = this.cacheKeys.package(deploymentId);
     const cachedPackages = await this.cache.get(cacheKey);
     if (cachedPackages) {
       return JSON.parse(cachedPackages);
@@ -870,7 +875,7 @@ export class D1StorageProvider implements StorageProvider {
       .set({ deletedAt: Date.now() })
       .where(eq(schema.packages.deploymentId, deploymentId));
 
-    const cacheKey = this.cacheKeys.package(accountId, appId, deploymentId);
+    const cacheKey = this.cacheKeys.package(deploymentId);
     await this.cache.del(cacheKey);
 
     // Insert new history
@@ -920,7 +925,7 @@ export class D1StorageProvider implements StorageProvider {
       .set(schema.packages)
       .where(eq(schema.packages.deploymentId, deploymentId));
 
-    const cacheKey = this.cacheKeys.package(accountId, appId, deploymentId);
+    const cacheKey = this.cacheKeys.package(deploymentId);
     await this.cache.del(cacheKey);
 
     // Delete all package blobs

--- a/apps/server/src/storage/storage.ts
+++ b/apps/server/src/storage/storage.ts
@@ -82,7 +82,7 @@ export interface StorageProvider {
     pkg: Omit<Package, "label">,
   ): Promise<Package>;
 
-  updatePackage(pkg: Package): Promise<Package>;
+  updatePackage(pkg: Package, deploymentId: string): Promise<Package>;
 
   getPackageHistory(
     accountId: string,

--- a/apps/server/test/storage/d1.test.ts
+++ b/apps/server/test/storage/d1.test.ts
@@ -96,7 +96,7 @@ describe("D1StorageProvider Cache", () => {
 
     expect(result.length).toBe(1);
     expect(
-      await mockCache.get(`package:${account.id}:${app.id}:${deployment.id}`),
+      await mockCache.get(`package:${deployment.id}`),
     ).toBe(JSON.stringify(result));
   });
 
@@ -109,7 +109,7 @@ describe("D1StorageProvider Cache", () => {
     // First get to populate cache
     await storage.getPackageHistory(account.id, app.id, deployment.id);
     expect(
-      await mockCache.get(`package:${account.id}:${app.id}:${deployment.id}`),
+      await mockCache.get(`package:${deployment.id}`),
     ).toBeDefined();
 
     // Create test blob data
@@ -136,7 +136,7 @@ describe("D1StorageProvider Cache", () => {
 
     // Cache should be invalidated
     expect(
-      await mockCache.get(`package:${account.id}:${app.id}:${deployment.id}`),
+      await mockCache.get(`package:${deployment.id}`),
     ).toBeNull();
   });
 
@@ -155,7 +155,7 @@ describe("D1StorageProvider Cache", () => {
 
     expect(result.length).toBe(1);
     expect(
-      await mockCache.get(`package:${account.id}:${app.id}:${deployment.id}`),
+      await mockCache.get(`package:${deployment.id}`),
     ).toBe(JSON.stringify(result));
   });
 });

--- a/apps/web/src/pages/history/HistoryPage.tsx
+++ b/apps/web/src/pages/history/HistoryPage.tsx
@@ -175,13 +175,10 @@ export const HistoryPage = () => {
   const onToggleDisable = (item: MergedItem) => {
     if (!item.label) return;
     const willDisable = !item.isDisabled;
-    const enableWarning = willDisable
-      ? ""
-      : "\n\n⚠️ 서버가 재활성화(isDisabled:false)를 무시하는 상태일 수 있습니다. 반영되지 않으면 서버 수정이 필요합니다.";
     const confirmed = window.confirm(
       `Label: ${item.label}\nDescription: ${item.description ?? "-"}\n\n이 버전을 ${
         willDisable ? "비활성화" : "활성화"
-      }하시겠습니까?${enableWarning}`,
+      }하시겠습니까?`,
     );
     if (!confirmed) return;
     disableMutation.mutate({ label: item.label, isDisabled: willDisable });


### PR DESCRIPTION
# 요약

CodePush 릴리즈를 **다시 활성화(enable)해도 반영되지 않던 버그**와, enable/disable이 최대 5분간 반영되지 않던 **히스토리 캐시 무효화 누락**을 수정합니다. [FE-63](https://yplabs.atlassian.net/browse/FE-63)

## 증상 / 문제 상황

- 웹/CLI에서 비활성화한 릴리즈를 다시 활성화(`isDisabled:false`)해도 그대로 disabled 유지.
- 상태를 바꿔도 히스토리 목록에 최대 5분간 이전 값이 노출.

## 원인 분석

1. release update 핸들러가 `if (packageInfo.isDisabled)` **truthy 게이트** → `false`면 조건이 거짓이라 재활성화 요청이 통째로 스킵됨 (`management.ts`).
2. `updatePackage`가 DB row만 갱신하고 **히스토리 캐시를 무효화하지 않음** → `getPackageHistory`가 5분 TTL 동안 stale 반환.
3. 캐시 키가 `package:{accountId}:{appId}:{deploymentId}` 조합이라 같은 배포가 호출부별(관리/OTA/diff)로 **다중 캐시**됨. `getPackageHistory`는 실제로 `deploymentId`로만 조회하므로 accountId/appId는 불필요하며, 이 조합 키 때문에 한 키만 지워도 **OTA용 캐시가 stale로 남는** 구조적 결함.

## 수정

**근본**
- enable 게이트를 `if (packageInfo.isDisabled != null)`로 변경 → `false`도 정상 반영.
- 캐시 키를 **`package:{deploymentId}` 단일 키로 통일** → 호출부(관리/OTA/diff)가 같은 엔트리 공유.
- `updatePackage(pkg, deploymentId)`로 시그니처 확장 → 상태 변경 직후 해당 배포 캐시 무효화. OTA 업데이트 체크도 즉시 최신 `isDisabled` 반영.

**방어/정리**
- 웹: "서버가 재활성화를 무시할 수 있다"는 임시 경고 문구 제거(`HistoryPage.tsx`).

## 변경하지 않은 것

- `getPackageHistory`/`commitPackage` 등의 `accountId`/`appId` 파라미터는 `StorageProvider` 인터페이스 계약이라 시그니처 유지(캐시 키에서만 미사용).

## 테스트

- 로컬 서버(prod DB 스냅샷 **사본**, 격리)에서 검증:
  - fresh 캐시 + DB disabled 상태에서 **버그 재현** 확인(enable 무시).
  - 수정 후 disable→enable 왕복이 **응답·DB·히스토리 조회에 즉시 반영**(캐시 무효화 동작).
- `apps/server`: `tsc` EXIT=0, `biome check`(error 레벨) 통과, **vitest 115개 통과**(캐시 키 변경에 맞춰 `d1.test.ts` 기대값 갱신).
- `apps/web`: `tsc` EXIT=0.

## 참고

- 실서버 반영에는 **서버 재배포**(`wrangler publish`)가 필요합니다. 이 레포엔 자동배포 워크플로우가 없어 머지만으로는 prod에 반영되지 않습니다.

[FE-63]: https://yplabs.atlassian.net/browse/FE-63?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ