### PR TITLE
[FE-64 -> main] feat: 서버 릴리즈 Slack 알림 (업로드/활성화/비활성화)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,158 @@
+# 실행 · 배포 가이드
+
+CodePush 서버/웹의 로컬 실행과 배포 방법 (명령어 위주).
+
+## 0. 프로젝트 구조
+
+모노레포 (pnpm + turbo):
+
+| 경로 | 내용 |
+| --- | --- |
+| `apps/server` | Hono 기반 Cloudflare Worker (D1 + R2) |
+| `apps/web` | Vite + React SPA |
+| `packages/api-client` | 서버 OpenAPI에서 생성한 typescript-axios 클라이언트 |
+
+배포 대상:
+
+| | 워커 | URL | D1 | 배포 방식 |
+| --- | --- | --- | --- | --- |
+| 서버 | `code-push-server-preview` | `code-push-server-preview.yplabs.workers.dev` | `codepush-server-prod` | **main 머지 시 자동** (Cloudflare Workers Builds) |
+| 웹 | `codepush-web` | `codepush-web.yplabs.workers.dev` | — | **수동** (`pnpm deploy`) |
+
+## 1. 공통 준비
+
+```bash
+pnpm install
+```
+
+- ⚠️ `wrangler` / `node` 실행 전에 반드시 `unset NODE_OPTIONS` (안 하면 preload 스크립트 관련 크래시).
+- Cloudflare 로그인: `npx wrangler login` (`npx wrangler whoami`로 확인).
+
+---
+
+## 2. 서버 (`apps/server`)
+
+### 2-1. 로컬 실행
+
+```bash
+cd apps/server
+unset NODE_OPTIONS
+wrangler dev --env local          # http://localhost:8787, 로컬 D1(sqlite)
+```
+
+`.dev.vars` (git ignore됨) 예시:
+
+```
+JWT_SECRET=local-dev-secret
+ACCOUNT_ID=dummy
+R2_BUCKET_NAME=code-push-storage
+R2_ACCESS_KEY_ID=dummy
+R2_SECRET_ACCESS_KEY=dummy
+GITHUB_CLIENT_SECRET=dummy
+```
+
+### 2-2. 프로덕션 DB를 로컬로 안전 복제해서 테스트
+
+> 원칙: prod에서는 **export(읽기)만**. 모든 쓰기는 로컬 사본에만 → prod 무영향.
+
+```bash
+cd apps/server
+unset NODE_OPTIONS
+
+# 1) prod D1 덤프 (원격 읽기 전용)
+wrangler d1 export DB --env production --remote --output /tmp/prod.sql
+
+# 2) (선택) 대용량 텔레메트리 테이블 제외 → 주입 빠르게
+grep -v '^INSERT INTO "client_label"' /tmp/prod.sql > /tmp/prod-trim.sql
+
+# 3) 로컬 D1 파일 생성: dev를 한 번 띄웠다 끄면 sqlite 파일이 만들어짐
+wrangler dev --env local          # 뜨면 Ctrl+C
+DB_FILE=$(find .wrangler/state/v3/d1 -name '*.sqlite' | head -1)
+
+# 4) sqlite3로 직접 주입
+#    (wrangler d1 execute --file 은 DDL+DML 혼합 파일에서 실패하므로 sqlite3 사용)
+sqlite3 "$DB_FILE" < /tmp/prod-trim.sql
+
+# 5) 로컬 서버 = 완전 격리된 사본
+wrangler dev --env local          # http://localhost:8787
+```
+
+인증 우회 (사본에 실계정이 있으니 그 accountId로 JWT 발급):
+
+```bash
+# .dev.vars 의 JWT_SECRET 과 동일 키로 HS256 서명 (@tsndr/cloudflare-worker-jwt)
+# payload: { sub: "<accountId>", email: "<email>" }
+curl http://localhost:8787/apps/<app>/deployments/<deployment>/history \
+  -H "Authorization: Bearer <발급한 JWT>"
+```
+
+- accountId 확인: `sqlite3 "$DB_FILE" "SELECT id, email FROM account;"`
+- enable/disable·협업자 변경 등 **쓰기는 전부 사본에만** 반영 → prod 안전.
+- R2 블롭은 복제되지 않음(더미 creds) → 번들 다운로드만 불가, 히스토리/플래그/협업자/회원 테스트엔 무관.
+
+### 2-3. 배포
+
+- **자동**: `main` 브랜치에 머지되면 Cloudflare Workers Builds가 `code-push-server-preview`를 자동 배포한다. (대시보드 연동 설정이며 레포 YAML에는 없음.)
+- **수동**:
+  ```bash
+  cd apps/server && unset NODE_OPTIONS
+  pnpm publish        # = wrangler deploy --env production
+  ```
+- **배포 확인**: `wrangler deployments list --env production`
+- **CI**: `.github/workflows/test.yml` — PR / main push 시 `apps/server`에서 `pnpm typecheck` + `pnpm check`(biome) + `pnpm test`(vitest).
+
+### 2-4. 프로덕션 D1 직접 조회/수정
+
+```bash
+cd apps/server && unset NODE_OPTIONS
+wrangler d1 execute DB --env production --remote --command "SELECT ..."   # 읽기
+wrangler d1 execute DB --env production --remote --command "UPDATE ..."   # 쓰기(주의)
+```
+
+---
+
+## 3. 웹 (`apps/web`)
+
+### 3-1. 로컬 실행
+
+```bash
+cd apps/web
+unset NODE_OPTIONS
+pnpm dev            # http://localhost:5173
+```
+
+- API 주소는 `VITE_API_URL`. 우선순위상 `.env.local`(prod 서버 지정)이 `.env.development`(localhost)를 덮으므로, **로컬 서버로 강제**하려면 `.env.development.local` 생성:
+  ```
+  VITE_API_URL=http://localhost:8787
+  ```
+- 로컬 서버에 붙일 때 인증: 인증은 `session` httpOnly 쿠키 방식. 브라우저 콘솔에서 로컬 JWT를 쿠키로 주입:
+  ```js
+  document.cookie = "session=<발급한 JWT>; path=/";
+  ```
+
+### 3-2. 배포 (수동 — 자동 배포 없음)
+
+```bash
+cd apps/web
+unset NODE_OPTIONS
+pnpm deploy          # = pnpm build && wrangler deploy → codepush-web
+```
+
+- 프로덕션 `VITE_API_URL`은 `.env.production` / `.env.local` (prod 서버).
+- 배포 직후 엣지 캐시로 이전 HTML이 잠깐 보일 수 있음(잠시 후 갱신).
+
+---
+
+## 4. api-client 재생성
+
+서버 라우트가 바뀌면 클라이언트를 재생성한다. **로컬 서버가 떠 있어야 한다** (`localhost:8787/docs` 참조).
+
+```bash
+# 터미널 A: 서버 실행
+cd apps/server && unset NODE_OPTIONS && wrangler dev --env local
+
+# 터미널 B: 재생성 + 빌드
+cd packages/api-client && unset NODE_OPTIONS
+pnpm generate        # openapi 생성 + fix-colon-paths 정규화 자동
+pnpm build           # dist 빌드 (웹이 이 dist를 사용)
+```

--- a/apps/server/src/routes/management.ts
+++ b/apps/server/src/routes/management.ts
@@ -27,6 +27,7 @@ import {
   generateDeploymentKey,
   generateKey,
 } from "../utils/security";
+import { sendReleaseNotification } from "../utils/slack";
 import { urlEncode } from "../utils/urlencode";
 
 const router = new OpenAPIHono<Env>();
@@ -1329,6 +1330,24 @@ router.openapi(routes.deployments.release.create, async (c) => {
     "Location",
     urlEncode`/apps/${appName}/deployments/${deploymentName}`,
   );
+
+  const account = await storage.getAccount(accountId);
+  if (c.executionCtx) {
+    c.executionCtx.waitUntil(
+      sendReleaseNotification(c.env, {
+        appName: app.name,
+        deploymentName,
+        label: releasedPackage.label,
+        appVersion: releasedPackage.appVersion,
+        description: releasedPackage.description,
+        isMandatory: releasedPackage.isMandatory,
+        isDisabled: releasedPackage.isDisabled,
+        action: "Uploaded",
+        releasedBy: account.name || account.email,
+      }),
+    );
+  }
+
   return c.json({ package: releasedPackage }, 201);
 });
 
@@ -1385,6 +1404,25 @@ router.openapi(routes.deployments.release.update, async (c) => {
   }
 
   await storage.updatePackage(updatedRelease, deployment.id);
+
+  // isDisabled 토글이 포함된 요청일 때만 Slack 알림(rollout/version 등 다른 수정은 제외)
+  if (packageInfo.isDisabled != null && c.executionCtx) {
+    const account = await storage.getAccount(accountId);
+    c.executionCtx.waitUntil(
+      sendReleaseNotification(c.env, {
+        appName: app.name,
+        deploymentName,
+        label: updatedRelease.label,
+        appVersion: updatedRelease.appVersion,
+        description: updatedRelease.description,
+        isMandatory: updatedRelease.isMandatory,
+        isDisabled: updatedRelease.isDisabled,
+        action: updatedRelease.isDisabled ? "Disabled" : "Enabled",
+        releasedBy: account.name || account.email,
+      }),
+    );
+  }
+
   return c.json({ release: updatedRelease });
 });
 

--- a/apps/server/src/types/env.ts
+++ b/apps/server/src/types/env.ts
@@ -20,5 +20,7 @@ export interface Env {
     AWS_ACCESS_KEY_ID: string;
     AWS_SECRET_ACCESS_KEY: string;
     AWS_S3_BUCKET_NAME: string;
+    // Slack 릴리즈 알림 webhook의 /services/ 뒤 path segment. 미설정 시 알림 스킵.
+    CODE_PUSH_NOTI_SLACK?: string;
   };
 }

--- a/apps/server/src/utils/slack.ts
+++ b/apps/server/src/utils/slack.ts
@@ -1,0 +1,89 @@
+import type { Env } from "../types/env";
+
+type ReleaseActionType = "Uploaded" | "Enabled" | "Disabled";
+
+const SLACK_WEBHOOK_BASE = "https://hooks.slack.com/services";
+
+const ACTION_HEADER: Record<ReleaseActionType, string> = {
+  Uploaded: "새 릴리즈 업로드",
+  Enabled: "릴리즈 활성화",
+  Disabled: "릴리즈 비활성화",
+};
+
+const ACTION_EMOJI: Record<ReleaseActionType, string> = {
+  Uploaded: "🚀",
+  Enabled: "🟢",
+  Disabled: "🔴",
+};
+
+type ReleaseNotificationType = {
+  appName: string;
+  deploymentName: string;
+  label?: string;
+  appVersion: string;
+  description?: string;
+  isMandatory?: boolean;
+  isDisabled?: boolean;
+  action: ReleaseActionType;
+  releasedBy?: string;
+};
+
+/**
+ * 릴리즈 이벤트를 Slack 채널로 알린다(fire-and-forget 용).
+ * CODE_PUSH_NOTI_SLACK 미설정 시 조용히 스킵. 절대 throw 하지 않는다
+ * (waitUntil unhandled rejection 방지).
+ */
+export const sendReleaseNotification = async (
+  env: Env["Bindings"],
+  info: ReleaseNotificationType,
+): Promise<void> => {
+  try {
+    if (!env.CODE_PUSH_NOTI_SLACK) return;
+
+    const platform = info.appName.toLowerCase().includes("android")
+      ? "Android"
+      : "iOS";
+    const header = `${ACTION_EMOJI[info.action]} ${platform} · ${ACTION_HEADER[info.action]}`;
+
+    // 라벨 + 앱 버전을 굵게, 설명은 있을 때만 다음 줄에.
+    const summary = `*${info.label || "-"}*  ·  App ${info.appVersion}`;
+    const body = info.description ? `${summary}\n${info.description}` : summary;
+
+    // 부가 정보는 작은 context 줄로 (Deployment · Mandatory · Disabled · 작성자)
+    const context = [
+      `📦 ${info.deploymentName}`,
+      `Mandatory ${info.isMandatory ? "✅" : "❌"}`,
+      `Disabled ${info.isDisabled ? "✅" : "❌"}`,
+      `👤 ${info.releasedBy || "-"}`,
+    ].join("   ·   ");
+
+    const blocks = [
+      {
+        type: "header",
+        text: { type: "plain_text", text: header, emoji: true },
+      },
+      { type: "section", text: { type: "mrkdwn", text: body } },
+      {
+        type: "context",
+        elements: [{ type: "mrkdwn", text: context }],
+      },
+    ];
+
+    const res = await fetch(
+      `${SLACK_WEBHOOK_BASE}/${env.CODE_PUSH_NOTI_SLACK}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: header, blocks }),
+      },
+    );
+
+    if (!res.ok) {
+      console.error(
+        `Slack notification failed: ${res.status} ${await res.text()}`,
+      );
+    }
+  } catch (error) {
+    console.error("Slack notification error:", error);
+  }
+};

--- a/apps/web/src/pages/history/HistoryPage.tsx
+++ b/apps/web/src/pages/history/HistoryPage.tsx
@@ -17,7 +17,13 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { api } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ChevronLeft, ChevronRight, RefreshCw } from "lucide-react";
+import {
+  ChevronLeft,
+  ChevronRight,
+  ChevronsLeft,
+  ChevronsRight,
+  RefreshCw,
+} from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 
 const PAGE_SIZE = 20;
@@ -371,6 +377,14 @@ export const HistoryPage = () => {
                 variant="outline"
                 size="sm"
                 disabled={page <= 1 || isFetching}
+                onClick={() => setPage(1)}
+              >
+                <ChevronsLeft className="h-4 w-4" />
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page <= 1 || isFetching}
                 onClick={() => setPage((prev) => Math.max(1, prev - 1))}
               >
                 <ChevronLeft className="mr-1 h-4 w-4" />
@@ -384,6 +398,14 @@ export const HistoryPage = () => {
               >
                 다음
                 <ChevronRight className="ml-1 h-4 w-4" />
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page >= totalPages || isFetching}
+                onClick={() => setPage(totalPages)}
+              >
+                <ChevronsRight className="h-4 w-4" />
               </Button>
             </div>
           </div>


### PR DESCRIPTION
# 요약
> 서버의 실제 릴리즈 처리 지점에서 Slack 채널로 릴리즈 알림을 전송한다. 신규 업로드 / 활성화 / 비활성화 3개 이벤트 대상.

- PRD: 없음
- Figma: 없음

## 배경
- 기존 Slack 알림은 웹(`cnt-codepush-web`)의 릴리즈 update(PATCH)에서 `isDisabled`일 때만 발사됐다. 서버 릴리즈 지점이 아니라 웹 레이어라 신규 업로드는 알림이 없었다.
- 알림 트리거를 서버의 실제 릴리즈 지점으로 옮기고, 신규 업로드까지 범위를 넓힌다. Promote/Rollback은 대상 아님.

## 변경 사항

- **`apps/server/src/utils/slack.ts`** (신규) — 릴리즈 이벤트 Slack 알림 유틸
  - Before: 서버에 Slack/webhook 코드 전무
  - After: `sendReleaseNotification(env, info)`가 이벤트를 Slack blocks 메시지로 전송
  - 세부:
    - `CODE_PUSH_NOTI_SLACK`(webhook의 `/services/` 뒤 path segment) 미설정 시 조용히 return → 미설정 배포에서도 릴리즈 정상 동작
    - webhook URL은 `https://hooks.slack.com/services/${CODE_PUSH_NOTI_SLACK}` (cnt-codepush-web와 동일 값 재사용)
    - `action`(`Uploaded`/`Enabled`/`Disabled`)별 헤더 이모지·문구 분기 (🚀/🟢/🔴)
    - 메시지 3단 구성: header / 라벨·버전·설명 section / 부가정보(Deployment·Mandatory·Disabled·작성자) context
    - platform은 `appName`에 `android` 포함 여부로 판정
    - 최상단 try/catch로 절대 throw 안 함 (`waitUntil` unhandled rejection 방지)

- **`apps/server/src/routes/management.ts`** — 2개 핸들러에 알림 훅 추가
  - Before: 릴리즈 커밋 후 알림 없음
  - After: 반환 직전 `c.executionCtx.waitUntil(...)`로 fire-and-forget 알림
  - 세부:
    - `release.create` → `action: "Uploaded"`
    - `release.update` → `packageInfo.isDisabled != null`일 때만 발사, `Disabled`/`Enabled` 분기 (rollout·version만 바꾸는 PATCH는 알림 없음)
    - 작성자는 `storage.getAccount(accountId)`의 `name`(없으면 `email`)
    - 응답은 알림을 기다리지 않고 즉시 반환 → 알림 실패가 릴리즈에 영향 없음

- **`apps/server/src/types/env.ts`** — `Bindings`에 `CODE_PUSH_NOTI_SLACK?: string` 추가
  - optional → 미설정 시 알림 스킵

- **`apps/web/src/pages/history/HistoryPage.tsx`** — 페이지네이션 첫/마지막 이동 버튼
  - Before: 이전/다음 버튼만 존재
  - After: 처음(⏮) / 마지막(⏭) 페이지 이동 버튼 추가, disabled 조건은 이전/다음과 일치

- **`DEVELOPMENT.md`** (신규) — 로컬 실행·배포 가이드
  - 서버/웹 로컬 실행, 프로덕션 DB 안전 복제 테스트, 배포, api-client 재생성 절차 정리 (how 중심)

## 테스트
- [x] 로컬 서버(prod DB 복제본) + 웹에서 disable/enable 토글 → 실 Slack 채널 메시지 도착 확인
- [x] eslint(biome) / tsc 통과
- [ ] 유닛 테스트: 미작성. fire-and-forget + 외부 webhook 특성상 로컬 실채널 스모크로 대체 (요청에 따라 테스트 생략)

## 참고
> ⚠️ 머지 전 확인
> - **프로덕션 시크릿 등록 필요**: `cd apps/server && npx wrangler secret put CODE_PUSH_NOTI_SLACK --env production`. 미등록 시 알림만 스킵되고 릴리즈는 정상 동작.
> - 이 레포는 main 머지 시 Cloudflare Workers Builds가 서버(`code-push-server-preview`)를 **자동 배포**한다.
> - DB 마이그레이션·api-client 변경 없음. 웹 재배포는 페이지네이션 버튼 반영 시에만 별도 필요.
