### PR TITLE
[FE-69 -> develop] chore: Slack 알림에서 deployment 이름 제거 및 체크 표기 심플화

### DIFF
--- a/apps/server/src/routes/management.ts
+++ b/apps/server/src/routes/management.ts
@@ -1336,7 +1336,6 @@ router.openapi(routes.deployments.release.create, async (c) => {
     c.executionCtx.waitUntil(
       sendReleaseNotification(c.env, {
         appName: app.name,
-        deploymentName,
         label: releasedPackage.label,
         appVersion: releasedPackage.appVersion,
         description: releasedPackage.description,
@@ -1411,7 +1410,6 @@ router.openapi(routes.deployments.release.update, async (c) => {
     c.executionCtx.waitUntil(
       sendReleaseNotification(c.env, {
         appName: app.name,
-        deploymentName,
         label: updatedRelease.label,
         appVersion: updatedRelease.appVersion,
         description: updatedRelease.description,

--- a/apps/server/src/utils/slack.ts
+++ b/apps/server/src/utils/slack.ts
@@ -18,7 +18,6 @@ const ACTION_EMOJI: Record<ReleaseActionType, string> = {
 
 type ReleaseNotificationType = {
   appName: string;
-  deploymentName: string;
   label?: string;
   appVersion: string;
   description?: string;
@@ -49,11 +48,10 @@ export const sendReleaseNotification = async (
     const summary = `*${info.label || "-"}*  ·  App ${info.appVersion}`;
     const body = info.description ? `${summary}\n${info.description}` : summary;
 
-    // 부가 정보는 작은 context 줄로 (Deployment · Mandatory · Disabled · 작성자)
+    // 부가 정보는 작은 context 줄로 (Mandatory · Disabled · 작성자)
     const context = [
-      `📦 ${info.deploymentName}`,
-      `Mandatory ${info.isMandatory ? "✅" : "❌"}`,
-      `Disabled ${info.isDisabled ? "✅" : "❌"}`,
+      `Mandatory ${info.isMandatory ? "✓" : "✗"}`,
+      `Disabled ${info.isDisabled ? "✓" : "✗"}`,
       `👤 ${info.releasedBy || "-"}`,
     ].join("   ·   ");
 


### PR DESCRIPTION
# 요약
> 서버 릴리즈 Slack 알림(FE-64)에서 정보 가치 없는 deployment 이름을 제거하고, Mandatory/Disabled 체크 표기를 박스형 이모지에서 심플한 문자로 교체한다.

- PRD: 없음
- Figma: 없음

## 배경
- FE-64에서 서버가 릴리즈(업로드/활성화/비활성화) Slack 알림을 전송하도록 구현됨.
- 메시지 하단 context 줄에 `📦 {deploymentName}`이 노출되는데, 실사용 deployment가 Production 하나뿐이라 정보 가치가 없음.
- ✅/❌ 박스형 이모지가 시각적으로 과해 심플한 표기로 교체.

## 변경 사항

- **`apps/server/src/utils/slack.ts`** — 알림 context 줄 정리
  - Before: `📦 Production   ·   Mandatory ✅   ·   Disabled ❌   ·   👤 홍길동`
  - After: `Mandatory ✓   ·   Disabled ✗   ·   👤 홍길동`
  - 세부:
    - context 배열에서 `📦 ${info.deploymentName}` 항목 제거
    - `ReleaseNotificationType`에서 `deploymentName` 필드 제거 (참조 소멸)
    - 체크 표기 ✅/❌ → ✓/✗

- **`apps/server/src/routes/management.ts`** — 호출부에서 deploymentName 전달 제거
  - release.create(업로드 알림) / release.update(isDisabled 토글 알림) 2곳에서 `deploymentName` 인자 삭제

## 테스트
- [x] tsc 통과
- [x] biome 통과 (경고 1건은 기존 metrics 핸들러의 non-null assertion, 미변경 코드)
- [x] vitest 117/117 통과
> Slack 메시지 표시만 변경 — API 응답/DB/OTA(updateCheck) 무관.

## 참고
- Jira: https://yplabs.atlassian.net/browse/FE-69

🤖 Generated with [Claude Code](https://claude.com/claude-code)