### PR TITLE
[FE-67 -> develop] feat: 릴리즈 disabled/mandatory 전용 엔드포인트 분리 및 웹 mandatory 토글

### DIFF
--- a/apps/server/src/routes/management.ts
+++ b/apps/server/src/routes/management.ts
@@ -1297,109 +1297,133 @@ router.openapi(routes.deployments.release.create, async (c) => {
     });
   }
 
-  // Check if there's an unfinished rollout
-  if (
-    deployment.package?.rollout &&
-    deployment.package.rollout < 100 &&
-    !deployment.package.isDisabled
-  ) {
-    throw new HTTPException(409, {
-      message:
-        "Please update the previous release to 100% rollout before releasing a new package",
-    });
-  }
+  const releasePackage = async () => {
+    // Check if there's an unfinished rollout
+    if (
+      deployment.package?.rollout &&
+      deployment.package.rollout < 100 &&
+      !deployment.package.isDisabled
+    ) {
+      throw new HTTPException(409, {
+        message:
+          "Please update the previous release to 100% rollout before releasing a new package",
+      });
+    }
 
-  const packageData = await packageFile.arrayBuffer();
-  const differ = await createPackageDiffer(
-    storage,
-    app.id,
-    deployment.id,
-    packageData,
-  );
-  const manifestResult = await differ.generateManifest();
-  const packageHash = await manifestResult.computeHash();
-
-  // Check if this is a duplicate of the current release
-  const history = await storage.getPackageHistory(
-    accountId,
-    app.id,
-    deployment.id,
-  );
-  const lastPackage = history[history.length - 1];
-  if (lastPackage && lastPackage.packageHash === packageHash) {
-    throw new HTTPException(409, {
-      message:
-        "The uploaded package was not released because it is identical to the contents of the specified deployment's current release",
-    });
-  }
-
-  // Store package blob
-  const blobId = generateKey();
-  await storage.addBlob(blobId, packageData, packageData.byteLength);
-  const blobUrl = await storage.getBlobUrl(blobId);
-
-  // Store manifest if available
-  let manifestUrl = "";
-  if (manifestResult) {
-    const manifestBlobId = generateKey();
-    const manifestJson = manifestResult.serialize();
-    const manifestBuffer = new TextEncoder().encode(manifestJson);
-    await storage.addBlob(
-      manifestBlobId,
-      manifestBuffer,
-      manifestBuffer.length,
+    const packageData = await packageFile.arrayBuffer();
+    const differ = await createPackageDiffer(
+      storage,
+      app.id,
+      deployment.id,
+      packageData,
     );
-    manifestUrl = await storage.getBlobUrl(manifestBlobId);
-  }
+    const manifestResult = await differ.generateManifest();
+    const packageHash = await manifestResult.computeHash();
 
-  const newPackage: Omit<Package, "label"> = {
-    appVersion: packageInfo.appVersion,
-    description: packageInfo.description,
-    isDisabled: packageInfo.isDisabled || false,
-    isMandatory: packageInfo.isMandatory || false,
-    rollout: packageInfo.rollout,
-    packageHash,
-    size: packageData.byteLength,
-    blobUrl,
-    manifestBlobUrl: manifestUrl,
-    uploadTime: Date.now(),
-    releaseMethod: "Upload",
+    // Check if this is a duplicate of the current release
+    const history = await storage.getPackageHistory(
+      accountId,
+      app.id,
+      deployment.id,
+    );
+    const lastPackage = history[history.length - 1];
+    if (lastPackage && lastPackage.packageHash === packageHash) {
+      throw new HTTPException(409, {
+        message:
+          "The uploaded package was not released because it is identical to the contents of the specified deployment's current release",
+      });
+    }
+
+    // Store package blob
+    const blobId = generateKey();
+    await storage.addBlob(blobId, packageData, packageData.byteLength);
+    const blobUrl = await storage.getBlobUrl(blobId);
+
+    // Store manifest if available
+    let manifestUrl = "";
+    if (manifestResult) {
+      const manifestBlobId = generateKey();
+      const manifestJson = manifestResult.serialize();
+      const manifestBuffer = new TextEncoder().encode(manifestJson);
+      await storage.addBlob(
+        manifestBlobId,
+        manifestBuffer,
+        manifestBuffer.length,
+      );
+      manifestUrl = await storage.getBlobUrl(manifestBlobId);
+    }
+
+    const newPackage: Omit<Package, "label"> = {
+      appVersion: packageInfo.appVersion,
+      description: packageInfo.description,
+      isDisabled: packageInfo.isDisabled || false,
+      isMandatory: packageInfo.isMandatory || false,
+      rollout: packageInfo.rollout,
+      packageHash,
+      size: packageData.byteLength,
+      blobUrl,
+      manifestBlobUrl: manifestUrl,
+      uploadTime: Date.now(),
+      releaseMethod: "Upload",
+    };
+
+    const releasedPackage = await storage.commitPackage(
+      accountId,
+      app.id,
+      deployment.id,
+      newPackage,
+    );
+
+    // Generate diffs in background
+    if (manifestResult) {
+      await differ.generateDiffs(history);
+    }
+
+    c.header(
+      "Location",
+      urlEncode`/apps/${appName}/deployments/${deploymentName}`,
+    );
+
+    const account = await storage.getAccount(accountId);
+    if (c.executionCtx) {
+      c.executionCtx.waitUntil(
+        sendReleaseNotification(c.env, {
+          appName: app.name,
+          label: releasedPackage.label,
+          appVersion: releasedPackage.appVersion,
+          description: releasedPackage.description,
+          isMandatory: releasedPackage.isMandatory,
+          isDisabled: releasedPackage.isDisabled,
+          action: "Uploaded",
+          releasedBy: account.name || account.email,
+        }),
+      );
+    }
+
+    return c.json({ package: releasedPackage }, 201);
   };
 
-  const releasedPackage = await storage.commitPackage(
-    accountId,
-    app.id,
-    deployment.id,
-    newPackage,
-  );
-
-  // Generate diffs in background
-  if (manifestResult) {
-    await differ.generateDiffs(history);
+  // 인증·권한을 통과한 실제 업로드 시도의 실패(롤아웃 미완/중복 번들/R2·D1 오류)를 Slack에 알린다.
+  try {
+    return await releasePackage();
+  } catch (error) {
+    if (c.executionCtx) {
+      const account = await storage.getAccount(accountId).catch(() => null);
+      c.executionCtx.waitUntil(
+        sendReleaseNotification(c.env, {
+          appName: app.name,
+          appVersion: packageInfo.appVersion,
+          description: packageInfo.description,
+          isMandatory: packageInfo.isMandatory,
+          isDisabled: packageInfo.isDisabled,
+          action: "UploadFailed",
+          releasedBy: account ? account.name || account.email : undefined,
+          errorMessage: error instanceof Error ? error.message : String(error),
+        }),
+      );
+    }
+    throw error;
   }
-
-  c.header(
-    "Location",
-    urlEncode`/apps/${appName}/deployments/${deploymentName}`,
-  );
-
-  const account = await storage.getAccount(accountId);
-  if (c.executionCtx) {
-    c.executionCtx.waitUntil(
-      sendReleaseNotification(c.env, {
-        appName: app.name,
-        label: releasedPackage.label,
-        appVersion: releasedPackage.appVersion,
-        description: releasedPackage.description,
-        isMandatory: releasedPackage.isMandatory,
-        isDisabled: releasedPackage.isDisabled,
-        action: "Uploaded",
-        releasedBy: account.name || account.email,
-      }),
-    );
-  }
-
-  return c.json({ package: releasedPackage }, 201);
 });
 
 router.openapi(routes.deployments.release.update, async (c) => {

--- a/apps/server/src/routes/management.ts
+++ b/apps/server/src/routes/management.ts
@@ -1467,7 +1467,7 @@ router.openapi(routes.deployments.release.update, async (c) => {
         description: updatedRelease.description,
         isMandatory: updatedRelease.isMandatory,
         isDisabled: updatedRelease.isDisabled,
-        action: updatedRelease.isDisabled ? "Disabled" : "Enabled",
+        action: "Disabled",
         releasedBy: account.name || account.email,
       }),
     );
@@ -1531,7 +1531,7 @@ router.openapi(routes.deployments.release.updateDisabled, async (c) => {
         description: updatedRelease.description,
         isMandatory: updatedRelease.isMandatory,
         isDisabled: updatedRelease.isDisabled,
-        action: isDisabled ? "Disabled" : "Enabled",
+        action: "Disabled",
         releasedBy: account.name || account.email,
       }),
     );
@@ -1595,7 +1595,7 @@ router.openapi(routes.deployments.release.updateMandatory, async (c) => {
         description: updatedRelease.description,
         isMandatory: updatedRelease.isMandatory,
         isDisabled: updatedRelease.isDisabled,
-        action: isMandatory ? "MandatoryOn" : "MandatoryOff",
+        action: "Mandatory",
         releasedBy: account.name || account.email,
       }),
     );

--- a/apps/server/src/routes/management.ts
+++ b/apps/server/src/routes/management.ts
@@ -534,6 +534,58 @@ const routes = {
           },
         },
       }),
+      updateDisabled: createRoute({
+        method: "patch",
+        path: "/apps/:appName/deployments/:deploymentName/release/disabled",
+        description: "Update release disabled state",
+        request: {
+          params: z.object({
+            appName: z.string(),
+            deploymentName: z.string(),
+          }),
+          body: {
+            content: {
+              "application/json": {
+                schema: z.object({
+                  label: z.string().optional(),
+                  isDisabled: z.boolean(),
+                }),
+              },
+            },
+          },
+        },
+        responses: {
+          200: {
+            description: "Release disabled state updated successfully",
+          },
+        },
+      }),
+      updateMandatory: createRoute({
+        method: "patch",
+        path: "/apps/:appName/deployments/:deploymentName/release/mandatory",
+        description: "Update release mandatory state",
+        request: {
+          params: z.object({
+            appName: z.string(),
+            deploymentName: z.string(),
+          }),
+          body: {
+            content: {
+              "application/json": {
+                schema: z.object({
+                  label: z.string().optional(),
+                  isMandatory: z.boolean(),
+                }),
+              },
+            },
+          },
+        },
+        responses: {
+          200: {
+            description: "Release mandatory state updated successfully",
+          },
+        },
+      }),
     },
     history: createRoute({
       method: "get",
@@ -1416,6 +1468,134 @@ router.openapi(routes.deployments.release.update, async (c) => {
         isMandatory: updatedRelease.isMandatory,
         isDisabled: updatedRelease.isDisabled,
         action: updatedRelease.isDisabled ? "Disabled" : "Enabled",
+        releasedBy: account.name || account.email,
+      }),
+    );
+  }
+
+  return c.json({ release: updatedRelease });
+});
+
+router.openapi(routes.deployments.release.updateDisabled, async (c) => {
+  const storage = getStorageProvider(c);
+  const accountId = c.var.auth.accountId;
+  const { appName, deploymentName } = c.req.valid("param");
+  const { label, isDisabled } = c.req.valid("json");
+
+  const app = await storage.getApp(accountId, { appName });
+  if (!app) {
+    throw new HTTPException(404, {
+      message: `App "${appName}" not found`,
+    });
+  }
+
+  throwIfInvalidPermissions(app, "Collaborator");
+
+  const deployments = await storage.getDeployments(accountId, app.id);
+  const deployment = deployments.find((d) => d.name === deploymentName);
+
+  if (!deployment) {
+    throw new HTTPException(404, {
+      message: `Deployment "${deploymentName}" not found`,
+    });
+  }
+
+  const packageHistory = await storage.getPackageHistory(
+    accountId,
+    app.id,
+    deployment.id,
+  );
+
+  const release = label
+    ? packageHistory.find((p) => p.label === label)
+    : packageHistory[packageHistory.length - 1];
+
+  if (!release?.label) {
+    throw new HTTPException(404, {
+      message: "Release package not found",
+    });
+  }
+
+  const updatedRelease = { ...release, isDisabled };
+  await storage.updatePackageMetadata(deployment.id, release.label, {
+    isDisabled,
+  });
+
+  if (c.executionCtx) {
+    const account = await storage.getAccount(accountId);
+    c.executionCtx.waitUntil(
+      sendReleaseNotification(c.env, {
+        appName: app.name,
+        label: updatedRelease.label,
+        appVersion: updatedRelease.appVersion,
+        description: updatedRelease.description,
+        isMandatory: updatedRelease.isMandatory,
+        isDisabled: updatedRelease.isDisabled,
+        action: isDisabled ? "Disabled" : "Enabled",
+        releasedBy: account.name || account.email,
+      }),
+    );
+  }
+
+  return c.json({ release: updatedRelease });
+});
+
+router.openapi(routes.deployments.release.updateMandatory, async (c) => {
+  const storage = getStorageProvider(c);
+  const accountId = c.var.auth.accountId;
+  const { appName, deploymentName } = c.req.valid("param");
+  const { label, isMandatory } = c.req.valid("json");
+
+  const app = await storage.getApp(accountId, { appName });
+  if (!app) {
+    throw new HTTPException(404, {
+      message: `App "${appName}" not found`,
+    });
+  }
+
+  throwIfInvalidPermissions(app, "Collaborator");
+
+  const deployments = await storage.getDeployments(accountId, app.id);
+  const deployment = deployments.find((d) => d.name === deploymentName);
+
+  if (!deployment) {
+    throw new HTTPException(404, {
+      message: `Deployment "${deploymentName}" not found`,
+    });
+  }
+
+  const packageHistory = await storage.getPackageHistory(
+    accountId,
+    app.id,
+    deployment.id,
+  );
+
+  const release = label
+    ? packageHistory.find((p) => p.label === label)
+    : packageHistory[packageHistory.length - 1];
+
+  if (!release?.label) {
+    throw new HTTPException(404, {
+      message: "Release package not found",
+    });
+  }
+
+  const updatedRelease = { ...release, isMandatory };
+  await storage.updatePackageMetadata(deployment.id, release.label, {
+    isMandatory,
+  });
+
+  if (c.executionCtx) {
+    const account = await storage.getAccount(accountId);
+    c.executionCtx.waitUntil(
+      sendReleaseNotification(c.env, {
+        appName: app.name,
+        label: updatedRelease.label,
+        appVersion: updatedRelease.appVersion,
+        description: updatedRelease.description,
+        isMandatory: updatedRelease.isMandatory,
+        isDisabled: updatedRelease.isDisabled,
+        action: isMandatory ? "MandatoryOn" : "MandatoryOff",
         releasedBy: account.name || account.email,
       }),
     );

--- a/apps/server/src/storage/d1.ts
+++ b/apps/server/src/storage/d1.ts
@@ -880,6 +880,27 @@ export class D1StorageProvider implements StorageProvider {
     return pkg;
   }
 
+  // disabled/mandatory 토글 전용 부분 UPDATE. updatePackage(여러 필드 통째 SET)와 달리
+  // 대상 컬럼만 갱신한다 — 히스토리 캐시가 isolate별 메모리라 stale 캐시 기반으로 전체 필드를
+  // 쓰면 다른 isolate에서 방금 바꾼 필드를 되돌릴 수 있어(lost update), 토글은 이 경로를 쓴다.
+  async updatePackageMetadata(
+    deploymentId: string,
+    label: string,
+    updates: { isDisabled?: boolean; isMandatory?: boolean },
+  ): Promise<void> {
+    await this.db
+      .update(schema.packages)
+      .set(updates)
+      .where(
+        and(
+          eq(schema.packages.deploymentId, deploymentId),
+          eq(schema.packages.label, label),
+          isNull(schema.packages.deletedAt),
+        ),
+      );
+    await this.cache.del(this.cacheKeys.package(deploymentId));
+  }
+
   async getPackageHistory(
     accountId: string,
     appId: string,

--- a/apps/server/src/storage/storage.ts
+++ b/apps/server/src/storage/storage.ts
@@ -92,6 +92,12 @@ export interface StorageProvider {
 
   updatePackage(pkg: Package, deploymentId: string): Promise<Package>;
 
+  updatePackageMetadata(
+    deploymentId: string,
+    label: string,
+    updates: { isDisabled?: boolean; isMandatory?: boolean },
+  ): Promise<void>;
+
   getPackageHistory(
     accountId: string,
     appId: string,

--- a/apps/server/src/utils/slack.ts
+++ b/apps/server/src/utils/slack.ts
@@ -1,6 +1,11 @@
 import type { Env } from "../types/env";
 
-type ReleaseActionType = "Uploaded" | "Enabled" | "Disabled";
+type ReleaseActionType =
+  | "Uploaded"
+  | "Enabled"
+  | "Disabled"
+  | "MandatoryOn"
+  | "MandatoryOff";
 
 const SLACK_WEBHOOK_BASE = "https://hooks.slack.com/services";
 
@@ -8,12 +13,17 @@ const ACTION_HEADER: Record<ReleaseActionType, string> = {
   Uploaded: "새 릴리즈 업로드",
   Enabled: "릴리즈 활성화",
   Disabled: "릴리즈 비활성화",
+  MandatoryOn: "Mandatory 설정",
+  MandatoryOff: "Mandatory 해제",
 };
 
+// 헤더 블록에서 이모지는 크게 렌더링되므로 상태 토글류는 플레인 문자(✓/✕)를 쓴다.
 const ACTION_EMOJI: Record<ReleaseActionType, string> = {
   Uploaded: "🚀",
-  Enabled: "🟢",
-  Disabled: "🔴",
+  Enabled: "✓",
+  Disabled: "✕",
+  MandatoryOn: "✓",
+  MandatoryOff: "✕",
 };
 
 type ReleaseNotificationType = {

--- a/apps/server/src/utils/slack.ts
+++ b/apps/server/src/utils/slack.ts
@@ -1,12 +1,13 @@
 import type { Env } from "../types/env";
 
-type ReleaseActionType = "Uploaded" | "Disabled" | "Mandatory";
+type ReleaseActionType = "Uploaded" | "UploadFailed" | "Disabled" | "Mandatory";
 
 const SLACK_WEBHOOK_BASE = "https://hooks.slack.com/services";
 
 // 이모지·헤더는 액션 종류만 구분한다. on/off는 헤더 텍스트가 isDisabled/isMandatory 값으로 표현.
 const ACTION_EMOJI: Record<ReleaseActionType, string> = {
   Uploaded: "🚀",
+  UploadFailed: "🚨",
   Disabled: "🧊",
   Mandatory: "🔥",
 };
@@ -20,6 +21,7 @@ type ReleaseNotificationType = {
   isDisabled?: boolean;
   action: ReleaseActionType;
   releasedBy?: string;
+  errorMessage?: string;
 };
 
 /**
@@ -40,14 +42,21 @@ export const sendReleaseNotification = async (
     const headerLabel =
       info.action === "Uploaded"
         ? "새 릴리즈 업로드"
-        : info.action === "Disabled"
-          ? `Disabled ${info.isDisabled ?? false}`
-          : `Mandatory ${info.isMandatory ?? false}`;
+        : info.action === "UploadFailed"
+          ? "릴리즈 업로드 실패"
+          : info.action === "Disabled"
+            ? `Disabled ${info.isDisabled ?? false}`
+            : `Mandatory ${info.isMandatory ?? false}`;
     const header = `${ACTION_EMOJI[info.action]} ${platform} · ${headerLabel}`;
 
-    // 라벨 + 앱 버전을 굵게, 설명은 있을 때만 다음 줄에.
-    const summary = `*${info.label || "-"}*  ·  App ${info.appVersion}`;
-    const body = info.description ? `${summary}\n${info.description}` : summary;
+    // 라벨 + 앱 버전을 굵게, 설명·에러는 있을 때만 다음 줄에.
+    const body = [
+      `*${info.label || "-"}*  ·  App ${info.appVersion}`,
+      info.description,
+      info.errorMessage && `\`${info.errorMessage}\``,
+    ]
+      .filter(Boolean)
+      .join("\n");
 
     // 부가 정보는 작은 context 줄로 (Mandatory · Disabled · 작성자)
     const context = [

--- a/apps/server/src/utils/slack.ts
+++ b/apps/server/src/utils/slack.ts
@@ -17,14 +17,13 @@ const ACTION_HEADER: Record<ReleaseActionType, string> = {
   MandatoryOff: "Mandatory false",
 };
 
-// 헤더 블록에서 이모지는 크게 렌더링되므로 토글류는 플레인 문자를 쓴다.
-// 기호는 on/off가 아니라 카테고리 구분(Disabled=✕, Mandatory=★). on/off는 헤더 텍스트가 표현.
+// 기호는 on/off가 아니라 카테고리 구분(Disabled=🧊, Mandatory=🔥). on/off는 헤더 텍스트가 표현.
 const ACTION_EMOJI: Record<ReleaseActionType, string> = {
   Uploaded: "🚀",
-  Enabled: "✕",
-  Disabled: "✕",
-  MandatoryOn: "★",
-  MandatoryOff: "★",
+  Enabled: "🧊",
+  Disabled: "🧊",
+  MandatoryOn: "🔥",
+  MandatoryOff: "🔥",
 };
 
 type ReleaseNotificationType = {

--- a/apps/server/src/utils/slack.ts
+++ b/apps/server/src/utils/slack.ts
@@ -11,10 +11,10 @@ const SLACK_WEBHOOK_BASE = "https://hooks.slack.com/services";
 
 const ACTION_HEADER: Record<ReleaseActionType, string> = {
   Uploaded: "새 릴리즈 업로드",
-  Enabled: "릴리즈 활성화",
-  Disabled: "릴리즈 비활성화",
-  MandatoryOn: "Mandatory 설정",
-  MandatoryOff: "Mandatory 해제",
+  Enabled: "Disabled false",
+  Disabled: "Disabled true",
+  MandatoryOn: "Mandatory true",
+  MandatoryOff: "Mandatory false",
 };
 
 // 헤더 블록에서 이모지는 크게 렌더링되므로 상태 토글류는 플레인 문자(✓/✕)를 쓴다.

--- a/apps/server/src/utils/slack.ts
+++ b/apps/server/src/utils/slack.ts
@@ -17,13 +17,14 @@ const ACTION_HEADER: Record<ReleaseActionType, string> = {
   MandatoryOff: "Mandatory false",
 };
 
-// 헤더 블록에서 이모지는 크게 렌더링되므로 상태 토글류는 플레인 문자(✓/✕)를 쓴다.
+// 헤더 블록에서 이모지는 크게 렌더링되므로 토글류는 플레인 문자를 쓴다.
+// 기호는 on/off가 아니라 카테고리 구분(Disabled=✕, Mandatory=★). on/off는 헤더 텍스트가 표현.
 const ACTION_EMOJI: Record<ReleaseActionType, string> = {
   Uploaded: "🚀",
-  Enabled: "✓",
+  Enabled: "✕",
   Disabled: "✕",
-  MandatoryOn: "✓",
-  MandatoryOff: "✕",
+  MandatoryOn: "★",
+  MandatoryOff: "★",
 };
 
 type ReleaseNotificationType = {

--- a/apps/server/src/utils/slack.ts
+++ b/apps/server/src/utils/slack.ts
@@ -1,29 +1,14 @@
 import type { Env } from "../types/env";
 
-type ReleaseActionType =
-  | "Uploaded"
-  | "Enabled"
-  | "Disabled"
-  | "MandatoryOn"
-  | "MandatoryOff";
+type ReleaseActionType = "Uploaded" | "Disabled" | "Mandatory";
 
 const SLACK_WEBHOOK_BASE = "https://hooks.slack.com/services";
 
-const ACTION_HEADER: Record<ReleaseActionType, string> = {
-  Uploaded: "새 릴리즈 업로드",
-  Enabled: "Disabled false",
-  Disabled: "Disabled true",
-  MandatoryOn: "Mandatory true",
-  MandatoryOff: "Mandatory false",
-};
-
-// 기호는 on/off가 아니라 카테고리 구분(Disabled=🧊, Mandatory=🔥). on/off는 헤더 텍스트가 표현.
+// 이모지·헤더는 액션 종류만 구분한다. on/off는 헤더 텍스트가 isDisabled/isMandatory 값으로 표현.
 const ACTION_EMOJI: Record<ReleaseActionType, string> = {
   Uploaded: "🚀",
-  Enabled: "🧊",
   Disabled: "🧊",
-  MandatoryOn: "🔥",
-  MandatoryOff: "🔥",
+  Mandatory: "🔥",
 };
 
 type ReleaseNotificationType = {
@@ -52,7 +37,13 @@ export const sendReleaseNotification = async (
     const platform = info.appName.toLowerCase().includes("android")
       ? "Android"
       : "iOS";
-    const header = `${ACTION_EMOJI[info.action]} ${platform} · ${ACTION_HEADER[info.action]}`;
+    const headerLabel =
+      info.action === "Uploaded"
+        ? "새 릴리즈 업로드"
+        : info.action === "Disabled"
+          ? `Disabled ${info.isDisabled ?? false}`
+          : `Mandatory ${info.isMandatory ?? false}`;
+    const header = `${ACTION_EMOJI[info.action]} ${platform} · ${headerLabel}`;
 
     // 라벨 + 앱 버전을 굵게, 설명은 있을 때만 다음 줄에.
     const summary = `*${info.label || "-"}*  ·  App ${info.appVersion}`;

--- a/apps/server/test/routes/management.test.ts
+++ b/apps/server/test/routes/management.test.ts
@@ -1797,5 +1797,151 @@ describe("Management Routes", () => {
       expect(data.release.appVersion).toBe("1.0.0");
     });
   });
+
+  describe("PATCH /apps/:appName/deployments/:deploymentName/release/{disabled,mandatory}", () => {
+    let app: typeof schema.app.$inferInsert;
+    let deployment: typeof schema.deployment.$inferInsert;
+
+    beforeEach(async () => {
+      app = createTestApp();
+      await db.insert(schema.app).values(app);
+      await db.insert(schema.collaborator).values({
+        appId: app.id,
+        accountId: auth.getCurrentAccountId(),
+        permission: "Owner",
+      });
+      deployment = createTestDeployment(app.id);
+      await db.insert(schema.deployment).values(deployment);
+      // v1: disabled 상태, v2: mandatory 상태(최신) — 부분 UPDATE가 다른 필드를 건드리지 않는지 검증용
+      const package1 = createTestPackage(deployment.id, {
+        label: "v1",
+        appVersion: "1.0.0",
+        isDisabled: true,
+        uploadTime: Date.now() - 1000,
+      });
+      const package2 = createTestPackage(deployment.id, {
+        label: "v2",
+        appVersion: "1.0.1",
+        isMandatory: true,
+        uploadTime: Date.now(),
+      });
+      await db.insert(schema.packages).values(package1);
+      await db.insert(schema.packages).values(package2);
+      await Promise.all([
+        createTestBlob(package1.blobPath, "blob1"),
+        createTestBlob(package1.manifestBlobPath as string, "blob2"),
+        createTestBlob(package2.blobPath, "blob3"),
+        createTestBlob(package2.manifestBlobPath as string, "blob4"),
+      ]);
+    });
+
+    const fetchToggle = (
+      kind: "disabled" | "mandatory",
+      body: object,
+      headers: HeadersInit = {},
+    ) =>
+      SELF.fetch(
+        `https://example.com/apps/${app.name}/deployments/${deployment.name}/release/${kind}`,
+        { method: "PATCH", headers, body: JSON.stringify(body) },
+      );
+
+    const getRow = async (label: string) => {
+      const [row] = await db
+        .select()
+        .from(schema.packages)
+        .where(
+          and(
+            eq(schema.packages.deploymentId, deployment.id as string),
+            eq(schema.packages.label, label),
+          ),
+        );
+      return row;
+    };
+
+    it("disables a release by label without touching isMandatory", async () => {
+      const headers = await auth.getAuthHeaders();
+      const response = await fetchToggle(
+        "disabled",
+        { label: "v2", isDisabled: true },
+        headers,
+      );
+
+      expect(response.status).toBe(200);
+      const data: any = await response.json();
+      expect(data.release.label).toBe("v2");
+      expect(data.release.isDisabled).toBe(true);
+
+      const row = await getRow("v2");
+      expect(row.isDisabled).toBe(true);
+      expect(row.isMandatory).toBe(true); // 부분 UPDATE — mandatory 불변
+    });
+
+    it("enables a disabled release", async () => {
+      const headers = await auth.getAuthHeaders();
+      const response = await fetchToggle(
+        "disabled",
+        { label: "v1", isDisabled: false },
+        headers,
+      );
+
+      expect(response.status).toBe(200);
+      const row = await getRow("v1");
+      expect(row.isDisabled).toBe(false);
+    });
+
+    it("sets mandatory by label without touching isDisabled", async () => {
+      const headers = await auth.getAuthHeaders();
+      const response = await fetchToggle(
+        "mandatory",
+        { label: "v1", isMandatory: true },
+        headers,
+      );
+
+      expect(response.status).toBe(200);
+      const data: any = await response.json();
+      expect(data.release.label).toBe("v1");
+      expect(data.release.isMandatory).toBe(true);
+
+      const row = await getRow("v1");
+      expect(row.isMandatory).toBe(true);
+      expect(row.isDisabled).toBe(true); // 부분 UPDATE — disabled 불변
+    });
+
+    it("targets the latest release when label is omitted", async () => {
+      const headers = await auth.getAuthHeaders();
+      const response = await fetchToggle(
+        "mandatory",
+        { isMandatory: false },
+        headers,
+      );
+
+      expect(response.status).toBe(200);
+      const data: any = await response.json();
+      expect(data.release.label).toBe("v2");
+
+      const v2 = await getRow("v2");
+      expect(v2.isMandatory).toBe(false);
+      const v1 = await getRow("v1");
+      expect(v1.isMandatory).toBe(false); // 다른 행 불변
+    });
+
+    it("returns 404 for unknown label", async () => {
+      const headers = await auth.getAuthHeaders();
+      const response = await fetchToggle(
+        "disabled",
+        { label: "v99", isDisabled: true },
+        headers,
+      );
+      expect(response.status).toBe(404);
+    });
+
+    it("returns 401 when not authenticated", async () => {
+      const response = await fetchToggle("mandatory", {
+        label: "v1",
+        isMandatory: true,
+      });
+      expect(response.status).toBe(401);
+    });
+  });
 });
 

--- a/apps/server/vitest.config.ts
+++ b/apps/server/vitest.config.ts
@@ -24,6 +24,8 @@ export default defineWorkersProject(async () => {
             d1Databases: ["DB"],
             bindings: {
               TEST_MIGRATIONS: migrations,
+              // .dev.vars의 실제 webhook이 로드되면 테스트가 실채널로 Slack을 쏜다. 반드시 빈 값 고정.
+              CODE_PUSH_NOTI_SLACK: "",
               GITHUB_CLIENT_ID: "xxx",
               GITHUB_CLIENT_SECRET: "xxx",
               GITHUB_ORG: "test-org",

--- a/apps/web/src/pages/history/HistoryPage.tsx
+++ b/apps/web/src/pages/history/HistoryPage.tsx
@@ -174,10 +174,36 @@ export const HistoryPage = () => {
       label: string;
       isDisabled: boolean;
     }) =>
-      api.appsAppNameDeploymentsDeploymentNameReleasePatch(
+      api.appsAppNameDeploymentsDeploymentNameReleaseDisabledPatch(
         appName,
         deploymentName,
-        { packageInfo: { label, isDisabled } },
+        { label, isDisabled },
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["history", appName, deploymentName],
+      });
+    },
+    onError: (error) => {
+      const message =
+        (error as { response?: { data?: { message?: string } } })?.response
+          ?.data?.message ?? "릴리즈 업데이트에 실패했습니다.";
+      window.alert(message);
+    },
+  });
+
+  const mandatoryMutation = useMutation({
+    mutationFn: async ({
+      label,
+      isMandatory,
+    }: {
+      label: string;
+      isMandatory: boolean;
+    }) =>
+      api.appsAppNameDeploymentsDeploymentNameReleaseMandatoryPatch(
+        appName,
+        deploymentName,
+        { label, isMandatory },
       ),
     onSuccess: () => {
       queryClient.invalidateQueries({
@@ -202,6 +228,22 @@ export const HistoryPage = () => {
     );
     if (!confirmed) return;
     disableMutation.mutate({ label: item.label, isDisabled: willDisable });
+  };
+
+  const onToggleMandatory = (item: MergedItem) => {
+    if (!item.label) return;
+    const willMandatory = !item.isMandatory;
+    const confirmed = window.confirm(
+      `Label: ${item.label}\nDescription: ${item.description ?? "-"}\n\n이 버전을 ${
+        willMandatory ? "Mandatory로 설정" : "Optional로 해제"
+      }하시겠습니까?${
+        willMandatory
+          ? "\n\n⚠️ Mandatory 설정 시 이 버전 이전을 실행 중인 기기들의 다음 업데이트가 강제 업데이트로 승격됩니다."
+          : ""
+      }`,
+    );
+    if (!confirmed) return;
+    mandatoryMutation.mutate({ label: item.label, isMandatory: willMandatory });
   };
 
   const refetch = () => {
@@ -354,14 +396,24 @@ export const HistoryPage = () => {
                     <span className="text-xs tabular-nums text-muted-foreground">
                       {formatTime(item.uploadTime)}
                     </span>
-                    <Button
-                      variant={item.isDisabled ? "outline" : "destructive"}
-                      size="sm"
-                      disabled={disableMutation.isPending}
-                      onClick={() => onToggleDisable(item)}
-                    >
-                      {item.isDisabled ? "Enable" : "Disable"}
-                    </Button>
+                    <div className="flex items-center gap-1.5">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        disabled={mandatoryMutation.isPending}
+                        onClick={() => onToggleMandatory(item)}
+                      >
+                        {item.isMandatory ? "Optional" : "Mandatory"}
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        disabled={disableMutation.isPending}
+                        onClick={() => onToggleDisable(item)}
+                      >
+                        {item.isDisabled ? "Enable" : "Disable"}
+                      </Button>
+                    </div>
                   </div>
                 </CardContent>
               </Card>

--- a/apps/web/src/pages/history/HistoryPage.tsx
+++ b/apps/web/src/pages/history/HistoryPage.tsx
@@ -1,11 +1,4 @@
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import {
   Select,
   SelectContent,
@@ -14,248 +7,42 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { api } from "@/lib/api";
-import { cn } from "@/lib/utils";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import {
-  ChevronLeft,
-  ChevronRight,
-  ChevronsLeft,
-  ChevronsRight,
-  Power,
-  RefreshCw,
-  Zap,
-} from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
-
-const PAGE_SIZE = 20;
-
-// history 라우트는 서버 OpenAPI 응답 스키마가 비어 있어 api-client가 void로 생성한다.
-// 실제 응답은 { history, totalCount, page, pageSize } 이므로 여기서 형태를 명시한다.
-interface ReleaseHistoryItem {
-  label?: string;
-  appVersion?: string;
-  isMandatory?: boolean;
-  isDisabled?: boolean;
-  description?: string;
-  size?: number;
-  rollout?: number | null;
-  releaseMethod?: string;
-  uploadTime?: number;
-}
-interface HistoryResponse {
-  history: ReleaseHistoryItem[];
-  totalCount: number;
-  page: number;
-  pageSize: number;
-}
-interface MetricEntry {
-  active?: number;
-  downloads?: number;
-  installed?: number;
-  failed?: number;
-}
-type MergedItem = ReleaseHistoryItem & MetricEntry;
-
-function formatBytes(bytes?: number): string {
-  if (bytes == null || !Number.isFinite(bytes) || bytes < 0) return "-";
-  if (bytes < 1024) return `${bytes} B`;
-  const units = ["KB", "MB", "GB", "TB"] as const;
-  let value = bytes / 1024;
-  let unitIndex = 0;
-  while (value >= 1024 && unitIndex < units.length - 1) {
-    value /= 1024;
-    unitIndex += 1;
-  }
-  return `${value.toFixed(1)} ${units[unitIndex]}`;
-}
-
-function formatTime(ts?: number): string {
-  if (ts == null || !Number.isFinite(ts) || ts <= 0) return "-";
-  return new Date(ts).toLocaleString("ko-KR", {
-    year: "2-digit",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-  });
-}
+import { RefreshCw } from "lucide-react";
+import { HistoryPagination } from "./components/HistoryPagination";
+import { ReleaseCard } from "./components/ReleaseCard";
+import { useHistoryTarget } from "./hooks/useHistoryTarget";
+import { useReleaseHistory } from "./hooks/useReleaseHistory";
+import { useReleaseToggles } from "./hooks/useReleaseToggles";
 
 export const HistoryPage = () => {
-  const queryClient = useQueryClient();
-  const [appName, setAppName] = useState<string>("");
-  const [deploymentName, setDeploymentName] = useState<string>("");
-  const [page, setPage] = useState<number>(1);
-
-  const { data: appsData } = useQuery({
-    queryKey: ["apps"],
-    queryFn: async () => (await api.appsGet()).data,
-  });
-  const apps = appsData?.apps ?? [];
-
-  // 앱 목록 로드 시 첫 앱 선택
-  useEffect(() => {
-    if (!appName && apps.length > 0 && apps[0].name) {
-      setAppName(apps[0].name);
-    }
-  }, [apps, appName]);
-
-  const { data: deploymentsData } = useQuery({
-    queryKey: ["deployments", appName],
-    queryFn: async () => (await api.appsAppNameDeploymentsGet(appName)).data,
-    enabled: !!appName,
-  });
-  const deployments = deploymentsData?.deployments ?? [];
-
-  // 배포 목록 로드 시 Production 우선, 없으면 첫 배포 선택
-  useEffect(() => {
-    if (deployments.length === 0) return;
-    const names = deployments.map((d) => d.name).filter(Boolean) as string[];
-    if (deploymentName && names.includes(deploymentName)) return;
-    setDeploymentName(names.includes("Production") ? "Production" : names[0]);
-  }, [deployments, deploymentName]);
-
-  // 앱·배포를 바꾸면 첫 페이지로 되돌린다.
-  useEffect(() => {
-    setPage(1);
-  }, [appName, deploymentName]);
-
-  const historyEnabled = !!appName && !!deploymentName;
+  const {
+    apps,
+    deployments,
+    appName,
+    setAppName,
+    deploymentName,
+    setDeploymentName,
+    enabled,
+  } = useHistoryTarget();
 
   const {
-    data: historyData,
-    isLoading: isHistoryLoading,
-    isError: isHistoryError,
+    rows,
+    page,
+    setPage,
+    totalCount,
+    totalPages,
+    isLoading,
+    isError,
     isFetching,
-  } = useQuery({
-    queryKey: ["history", appName, deploymentName, page],
-    queryFn: async () => {
-      const response = await api.appsAppNameDeploymentsDeploymentNameHistoryGet(
-        appName,
-        deploymentName,
-        page,
-        PAGE_SIZE,
-      );
-      // 위 주석 참조: 서버 실제 응답 형태로 해석
-      return response.data as unknown as HistoryResponse;
-    },
-    enabled: historyEnabled,
-  });
+    refetch,
+  } = useReleaseHistory(appName, deploymentName, enabled);
 
-  const { data: metricsData } = useQuery({
-    queryKey: ["metrics", appName, deploymentName],
-    queryFn: async () =>
-      (
-        await api.appsAppNameDeploymentsDeploymentNameMetricsGet(
-          appName,
-          deploymentName,
-        )
-      ).data,
-    enabled: historyEnabled,
-  });
-
-  // 서버가 최신순 페이지를 내려주므로 정렬은 서버에 맡기고 지표만 병합한다.
-  const rows: MergedItem[] = useMemo(() => {
-    const history = historyData?.history ?? [];
-    const metrics = (metricsData?.metrics ?? {}) as Record<string, MetricEntry>;
-    return history.map((item) => ({
-      ...item,
-      ...(item.label ? metrics[item.label] : {}),
-    }));
-  }, [historyData, metricsData]);
-
-  const totalCount = historyData?.totalCount ?? 0;
-  const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE));
-
-  const disableMutation = useMutation({
-    mutationFn: async ({
-      label,
-      isDisabled,
-    }: {
-      label: string;
-      isDisabled: boolean;
-    }) =>
-      api.appsAppNameDeploymentsDeploymentNameReleaseDisabledPatch(
-        appName,
-        deploymentName,
-        { label, isDisabled },
-      ),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["history", appName, deploymentName],
-      });
-    },
-    onError: (error) => {
-      const message =
-        (error as { response?: { data?: { message?: string } } })?.response
-          ?.data?.message ?? "릴리즈 업데이트에 실패했습니다.";
-      window.alert(message);
-    },
-  });
-
-  const mandatoryMutation = useMutation({
-    mutationFn: async ({
-      label,
-      isMandatory,
-    }: {
-      label: string;
-      isMandatory: boolean;
-    }) =>
-      api.appsAppNameDeploymentsDeploymentNameReleaseMandatoryPatch(
-        appName,
-        deploymentName,
-        { label, isMandatory },
-      ),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["history", appName, deploymentName],
-      });
-    },
-    onError: (error) => {
-      const message =
-        (error as { response?: { data?: { message?: string } } })?.response
-          ?.data?.message ?? "릴리즈 업데이트에 실패했습니다.";
-      window.alert(message);
-    },
-  });
-
-  const onToggleDisable = (item: MergedItem) => {
-    if (!item.label) return;
-    const willDisable = !item.isDisabled;
-    const confirmed = window.confirm(
-      `Label: ${item.label}\nDescription: ${item.description ?? "-"}\n\n이 버전을 ${
-        willDisable ? "비활성화" : "활성화"
-      }하시겠습니까?`,
-    );
-    if (!confirmed) return;
-    disableMutation.mutate({ label: item.label, isDisabled: willDisable });
-  };
-
-  const onToggleMandatory = (item: MergedItem) => {
-    if (!item.label) return;
-    const willMandatory = !item.isMandatory;
-    const confirmed = window.confirm(
-      `Label: ${item.label}\nDescription: ${item.description ?? "-"}\n\n이 버전을 ${
-        willMandatory ? "Mandatory로 설정" : "Optional로 해제"
-      }하시겠습니까?${
-        willMandatory
-          ? "\n\n⚠️ Mandatory 설정 시 이 버전 이전을 실행 중인 기기들의 다음 업데이트가 강제 업데이트로 승격됩니다."
-          : ""
-      }`,
-    );
-    if (!confirmed) return;
-    mandatoryMutation.mutate({ label: item.label, isMandatory: willMandatory });
-  };
-
-  const refetch = () => {
-    queryClient.invalidateQueries({
-      queryKey: ["history", appName, deploymentName],
-    });
-    queryClient.invalidateQueries({
-      queryKey: ["metrics", appName, deploymentName],
-    });
-  };
+  const {
+    onToggleDisable,
+    onToggleMandatory,
+    isDisablePending,
+    isMandatoryPending,
+  } = useReleaseToggles(appName, deploymentName);
 
   return (
     <div className="flex flex-col gap-6">
@@ -301,18 +88,18 @@ export const HistoryPage = () => {
         <Button
           variant="outline"
           onClick={refetch}
-          disabled={isFetching || !historyEnabled}
+          disabled={isFetching || !enabled}
         >
           <RefreshCw className="mr-2 h-4 w-4" />
           {isFetching ? "로딩중..." : "새로고침"}
         </Button>
       </div>
 
-      {isHistoryLoading ? (
+      {isLoading ? (
         <div className="rounded-lg border p-8 text-center text-sm text-muted-foreground">
           데이터를 불러오는 중입니다...
         </div>
-      ) : isHistoryError ? (
+      ) : isError ? (
         <div className="rounded-lg border p-8 text-center text-sm text-destructive">
           이력을 불러오지 못했습니다. 새로고침하거나 다시 로그인해 주세요.
         </div>
@@ -324,159 +111,24 @@ export const HistoryPage = () => {
         <>
           <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
             {rows.map((item) => (
-              <Card
+              <ReleaseCard
                 key={item.label}
-                className={cn(
-                  (item.installed ?? 0) > 50 &&
-                    "border-l-4 border-l-emerald-500",
-                )}
-              >
-                <CardHeader className="pb-3">
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="flex min-w-0 items-baseline gap-2">
-                      <CardTitle className="font-mono text-base">
-                        {item.label}
-                      </CardTitle>
-                      <span className="font-mono text-xs text-muted-foreground">
-                        App {item.appVersion ?? "-"}
-                      </span>
-                    </div>
-                    <div className="flex shrink-0 items-center gap-1.5">
-                      {item.isMandatory && (
-                        <Badge
-                          variant="outline"
-                          className="border-amber-300 bg-amber-50 text-amber-700"
-                        >
-                          Mandatory
-                        </Badge>
-                      )}
-                      {item.isDisabled ? (
-                        <Badge className="gap-1 border-transparent bg-red-50 text-red-700 hover:bg-red-50">
-                          <span className="h-1.5 w-1.5 rounded-full bg-current" />
-                          Disabled
-                        </Badge>
-                      ) : (
-                        <Badge className="gap-1 border-transparent bg-emerald-50 text-emerald-700 hover:bg-emerald-50">
-                          <span className="h-1.5 w-1.5 rounded-full bg-current" />
-                          Active
-                        </Badge>
-                      )}
-                    </div>
-                  </div>
-                  <p className="mt-2 min-h-[1.25rem] truncate text-sm text-muted-foreground">
-                    {item.description || "-"}
-                  </p>
-                </CardHeader>
-                <CardContent className="flex flex-col gap-4 pb-4">
-                  <div className="flex">
-                    <div className="flex-1 pr-3.5">
-                      <div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-                        Installed
-                      </div>
-                      <div className="mt-0.5 text-sm font-semibold tabular-nums">
-                        {(item.installed ?? 0).toLocaleString()}
-                      </div>
-                    </div>
-                    <div className="flex-1 border-l pl-3.5">
-                      <div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-                        Active
-                      </div>
-                      <div className="mt-0.5 text-sm font-semibold tabular-nums">
-                        {(item.active ?? 0).toLocaleString()}
-                      </div>
-                    </div>
-                    <div className="flex-1 border-l pl-3.5">
-                      <div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-                        Size
-                      </div>
-                      <div className="mt-0.5 text-sm font-semibold tabular-nums">
-                        {formatBytes(item.size)}
-                      </div>
-                    </div>
-                  </div>
-                  <div className="flex items-center justify-between gap-2">
-                    <span className="text-xs tabular-nums text-muted-foreground">
-                      {formatTime(item.uploadTime)}
-                    </span>
-                    <div className="flex items-center gap-1">
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        className="h-7 gap-1 px-2 text-xs [&_svg]:size-3"
-                        disabled={mandatoryMutation.isPending}
-                        onClick={() => onToggleMandatory(item)}
-                      >
-                        <Zap
-                          className={
-                            item.isMandatory
-                              ? "text-muted-foreground"
-                              : "text-amber-600"
-                          }
-                        />
-                        {item.isMandatory ? "Optional" : "Mandatory"}
-                      </Button>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        className="h-7 gap-1 px-2 text-xs [&_svg]:size-3"
-                        disabled={disableMutation.isPending}
-                        onClick={() => onToggleDisable(item)}
-                      >
-                        <Power
-                          className={
-                            item.isDisabled ? "text-emerald-600" : "text-red-600"
-                          }
-                        />
-                        {item.isDisabled ? "Enable" : "Disable"}
-                      </Button>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
+                item={item}
+                onToggleDisable={onToggleDisable}
+                onToggleMandatory={onToggleMandatory}
+                isDisablePending={isDisablePending}
+                isMandatoryPending={isMandatoryPending}
+              />
             ))}
           </div>
 
-          <div className="flex items-center justify-between">
-            <p className="text-sm text-muted-foreground">
-              전체 {totalCount}개 · {page}/{totalPages} 페이지
-            </p>
-            <div className="flex items-center gap-2">
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={page <= 1 || isFetching}
-                onClick={() => setPage(1)}
-              >
-                <ChevronsLeft className="h-4 w-4" />
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={page <= 1 || isFetching}
-                onClick={() => setPage((prev) => Math.max(1, prev - 1))}
-              >
-                <ChevronLeft className="mr-1 h-4 w-4" />
-                이전
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={page >= totalPages || isFetching}
-                onClick={() => setPage((prev) => prev + 1)}
-              >
-                다음
-                <ChevronRight className="ml-1 h-4 w-4" />
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={page >= totalPages || isFetching}
-                onClick={() => setPage(totalPages)}
-              >
-                <ChevronsRight className="h-4 w-4" />
-              </Button>
-            </div>
-          </div>
+          <HistoryPagination
+            page={page}
+            totalPages={totalPages}
+            totalCount={totalCount}
+            isFetching={isFetching}
+            onPageChange={setPage}
+          />
         </>
       )}
     </div>

--- a/apps/web/src/pages/history/HistoryPage.tsx
+++ b/apps/web/src/pages/history/HistoryPage.tsx
@@ -398,36 +398,34 @@ export const HistoryPage = () => {
                     <span className="text-xs tabular-nums text-muted-foreground">
                       {formatTime(item.uploadTime)}
                     </span>
-                    <div className="flex items-center gap-1.5">
+                    <div className="flex items-center gap-1">
                       <Button
                         variant="outline"
                         size="sm"
+                        className="h-7 gap-1 px-2 text-xs [&_svg]:size-3"
                         disabled={mandatoryMutation.isPending}
                         onClick={() => onToggleMandatory(item)}
                       >
                         <Zap
-                          className={cn(
-                            "mr-1 h-3 w-3",
+                          className={
                             item.isMandatory
                               ? "text-muted-foreground"
-                              : "text-amber-600",
-                          )}
+                              : "text-amber-600"
+                          }
                         />
                         {item.isMandatory ? "Optional" : "Mandatory"}
                       </Button>
                       <Button
                         variant="outline"
                         size="sm"
+                        className="h-7 gap-1 px-2 text-xs [&_svg]:size-3"
                         disabled={disableMutation.isPending}
                         onClick={() => onToggleDisable(item)}
                       >
                         <Power
-                          className={cn(
-                            "mr-1 h-3 w-3",
-                            item.isDisabled
-                              ? "text-emerald-600"
-                              : "text-red-600",
-                          )}
+                          className={
+                            item.isDisabled ? "text-emerald-600" : "text-red-600"
+                          }
                         />
                         {item.isDisabled ? "Enable" : "Disable"}
                       </Button>

--- a/apps/web/src/pages/history/HistoryPage.tsx
+++ b/apps/web/src/pages/history/HistoryPage.tsx
@@ -22,7 +22,9 @@ import {
   ChevronRight,
   ChevronsLeft,
   ChevronsRight,
+  Power,
   RefreshCw,
+  Zap,
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 
@@ -403,6 +405,14 @@ export const HistoryPage = () => {
                         disabled={mandatoryMutation.isPending}
                         onClick={() => onToggleMandatory(item)}
                       >
+                        <Zap
+                          className={cn(
+                            "mr-1 h-3 w-3",
+                            item.isMandatory
+                              ? "text-muted-foreground"
+                              : "text-amber-600",
+                          )}
+                        />
                         {item.isMandatory ? "Optional" : "Mandatory"}
                       </Button>
                       <Button
@@ -411,6 +421,14 @@ export const HistoryPage = () => {
                         disabled={disableMutation.isPending}
                         onClick={() => onToggleDisable(item)}
                       >
+                        <Power
+                          className={cn(
+                            "mr-1 h-3 w-3",
+                            item.isDisabled
+                              ? "text-emerald-600"
+                              : "text-red-600",
+                          )}
+                        />
                         {item.isDisabled ? "Enable" : "Disable"}
                       </Button>
                     </div>

--- a/apps/web/src/pages/history/components/HistoryPagination.tsx
+++ b/apps/web/src/pages/history/components/HistoryPagination.tsx
@@ -1,0 +1,67 @@
+import { Button } from "@/components/ui/button";
+import {
+  ChevronLeft,
+  ChevronRight,
+  ChevronsLeft,
+  ChevronsRight,
+} from "lucide-react";
+
+interface HistoryPaginationProps {
+  page: number;
+  totalPages: number;
+  totalCount: number;
+  isFetching: boolean;
+  onPageChange: (page: number) => void;
+}
+
+export const HistoryPagination = ({
+  page,
+  totalPages,
+  totalCount,
+  isFetching,
+  onPageChange,
+}: HistoryPaginationProps) => {
+  return (
+    <div className="flex items-center justify-between">
+      <p className="text-sm text-muted-foreground">
+        전체 {totalCount}개 · {page}/{totalPages} 페이지
+      </p>
+      <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={page <= 1 || isFetching}
+          onClick={() => onPageChange(1)}
+        >
+          <ChevronsLeft className="h-4 w-4" />
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={page <= 1 || isFetching}
+          onClick={() => onPageChange(Math.max(1, page - 1))}
+        >
+          <ChevronLeft className="mr-1 h-4 w-4" />
+          이전
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={page >= totalPages || isFetching}
+          onClick={() => onPageChange(page + 1)}
+        >
+          다음
+          <ChevronRight className="ml-1 h-4 w-4" />
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={page >= totalPages || isFetching}
+          onClick={() => onPageChange(totalPages)}
+        >
+          <ChevronsRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/apps/web/src/pages/history/components/ReleaseCard.tsx
+++ b/apps/web/src/pages/history/components/ReleaseCard.tsx
@@ -1,0 +1,158 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { Power, Zap } from "lucide-react";
+import type { MergedItem } from "../types";
+
+function formatBytes(bytes?: number): string {
+  if (bytes == null || !Number.isFinite(bytes) || bytes < 0) return "-";
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ["KB", "MB", "GB", "TB"] as const;
+  let value = bytes / 1024;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  return `${value.toFixed(1)} ${units[unitIndex]}`;
+}
+
+function formatTime(ts?: number): string {
+  if (ts == null || !Number.isFinite(ts) || ts <= 0) return "-";
+  return new Date(ts).toLocaleString("ko-KR", {
+    year: "2-digit",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+}
+
+interface ReleaseCardProps {
+  item: MergedItem;
+  onToggleDisable: (item: MergedItem) => void;
+  onToggleMandatory: (item: MergedItem) => void;
+  isDisablePending: boolean;
+  isMandatoryPending: boolean;
+}
+
+export const ReleaseCard = ({
+  item,
+  onToggleDisable,
+  onToggleMandatory,
+  isDisablePending,
+  isMandatoryPending,
+}: ReleaseCardProps) => {
+  return (
+    <Card
+      className={cn(
+        (item.installed ?? 0) > 50 && "border-l-4 border-l-emerald-500",
+      )}
+    >
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex min-w-0 items-baseline gap-2">
+            <CardTitle className="font-mono text-base">{item.label}</CardTitle>
+            <span className="font-mono text-xs text-muted-foreground">
+              App {item.appVersion ?? "-"}
+            </span>
+          </div>
+          <div className="flex shrink-0 items-center gap-1.5">
+            {item.isMandatory && (
+              <Badge
+                variant="outline"
+                className="border-amber-300 bg-amber-50 text-amber-700"
+              >
+                Mandatory
+              </Badge>
+            )}
+            {item.isDisabled ? (
+              <Badge className="gap-1 border-transparent bg-red-50 text-red-700 hover:bg-red-50">
+                <span className="h-1.5 w-1.5 rounded-full bg-current" />
+                Disabled
+              </Badge>
+            ) : (
+              <Badge className="gap-1 border-transparent bg-emerald-50 text-emerald-700 hover:bg-emerald-50">
+                <span className="h-1.5 w-1.5 rounded-full bg-current" />
+                Active
+              </Badge>
+            )}
+          </div>
+        </div>
+        <p className="mt-2 min-h-[1.25rem] truncate text-sm text-muted-foreground">
+          {item.description || "-"}
+        </p>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4 pb-4">
+        <div className="flex">
+          <div className="flex-1 pr-3.5">
+            <div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+              Installed
+            </div>
+            <div className="mt-0.5 text-sm font-semibold tabular-nums">
+              {(item.installed ?? 0).toLocaleString()}
+            </div>
+          </div>
+          <div className="flex-1 border-l pl-3.5">
+            <div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+              Active
+            </div>
+            <div className="mt-0.5 text-sm font-semibold tabular-nums">
+              {(item.active ?? 0).toLocaleString()}
+            </div>
+          </div>
+          <div className="flex-1 border-l pl-3.5">
+            <div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+              Size
+            </div>
+            <div className="mt-0.5 text-sm font-semibold tabular-nums">
+              {formatBytes(item.size)}
+            </div>
+          </div>
+        </div>
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-xs tabular-nums text-muted-foreground">
+            {formatTime(item.uploadTime)}
+          </span>
+          <div className="flex items-center gap-0.5">
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-7 gap-1 px-2 text-xs [&_svg]:size-3"
+              disabled={isMandatoryPending}
+              onClick={() => onToggleMandatory(item)}
+            >
+              <Zap
+                className={
+                  item.isMandatory ? "text-muted-foreground" : "text-amber-600"
+                }
+              />
+              {item.isMandatory ? "Optional" : "Mandatory"}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-7 gap-1 px-2 text-xs [&_svg]:size-3"
+              disabled={isDisablePending}
+              onClick={() => onToggleDisable(item)}
+            >
+              <Power
+                className={
+                  item.isDisabled ? "text-emerald-600" : "text-red-600"
+                }
+              />
+              {item.isDisabled ? "Enable" : "Disable"}
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/apps/web/src/pages/history/hooks/useHistoryTarget.ts
+++ b/apps/web/src/pages/history/hooks/useHistoryTarget.ts
@@ -1,0 +1,52 @@
+import { api } from "@/lib/api";
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+
+// 조회 대상(앱·배포) 선택 상태와 자동 선택 규칙
+export function useHistoryTarget() {
+  const [appName, setAppName] = useState<string>("");
+  const [deploymentName, setDeploymentName] = useState<string>("");
+
+  const { data: appsData } = useQuery({
+    queryKey: ["apps"],
+    queryFn: async () => (await api.appsGet()).data,
+  });
+  const apps = appsData?.apps ?? [];
+
+  useEffect(
+    function selectFirstAppOnLoad() {
+      if (!appName && apps.length > 0 && apps[0].name) {
+        setAppName(apps[0].name);
+      }
+    },
+    [apps, appName],
+  );
+
+  const { data: deploymentsData } = useQuery({
+    queryKey: ["deployments", appName],
+    queryFn: async () => (await api.appsAppNameDeploymentsGet(appName)).data,
+    enabled: !!appName,
+  });
+  const deployments = deploymentsData?.deployments ?? [];
+
+  // Production 우선, 없으면 첫 배포 선택
+  useEffect(
+    function selectDefaultDeployment() {
+      if (deployments.length === 0) return;
+      const names = deployments.map((d) => d.name).filter(Boolean) as string[];
+      if (deploymentName && names.includes(deploymentName)) return;
+      setDeploymentName(names.includes("Production") ? "Production" : names[0]);
+    },
+    [deployments, deploymentName],
+  );
+
+  return {
+    apps,
+    deployments,
+    appName,
+    setAppName,
+    deploymentName,
+    setDeploymentName,
+    enabled: !!appName && !!deploymentName,
+  };
+}

--- a/apps/web/src/pages/history/hooks/useReleaseHistory.ts
+++ b/apps/web/src/pages/history/hooks/useReleaseHistory.ts
@@ -1,0 +1,89 @@
+import { api } from "@/lib/api";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+import type { HistoryResponse, MergedItem, MetricEntry } from "../types";
+
+const PAGE_SIZE = 20;
+
+// 릴리즈 이력·지표 조회와 페이지 상태
+export function useReleaseHistory(
+  appName: string,
+  deploymentName: string,
+  enabled: boolean,
+) {
+  const queryClient = useQueryClient();
+  const [page, setPage] = useState<number>(1);
+
+  useEffect(
+    function resetPageOnTargetChange() {
+      setPage(1);
+    },
+    [appName, deploymentName],
+  );
+
+  const {
+    data: historyData,
+    isLoading,
+    isError,
+    isFetching,
+  } = useQuery({
+    queryKey: ["history", appName, deploymentName, page],
+    queryFn: async () => {
+      const response = await api.appsAppNameDeploymentsDeploymentNameHistoryGet(
+        appName,
+        deploymentName,
+        page,
+        PAGE_SIZE,
+      );
+      // types.ts 주석 참조: 서버 실제 응답 형태로 해석
+      return response.data as unknown as HistoryResponse;
+    },
+    enabled,
+  });
+
+  const { data: metricsData } = useQuery({
+    queryKey: ["metrics", appName, deploymentName],
+    queryFn: async () =>
+      (
+        await api.appsAppNameDeploymentsDeploymentNameMetricsGet(
+          appName,
+          deploymentName,
+        )
+      ).data,
+    enabled,
+  });
+
+  // 서버가 최신순 페이지를 내려주므로 정렬은 서버에 맡기고 지표만 병합한다.
+  const rows: MergedItem[] = useMemo(() => {
+    const history = historyData?.history ?? [];
+    const metrics = (metricsData?.metrics ?? {}) as Record<string, MetricEntry>;
+    return history.map((item) => ({
+      ...item,
+      ...(item.label ? metrics[item.label] : {}),
+    }));
+  }, [historyData, metricsData]);
+
+  const totalCount = historyData?.totalCount ?? 0;
+  const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE));
+
+  const refetch = () => {
+    queryClient.invalidateQueries({
+      queryKey: ["history", appName, deploymentName],
+    });
+    queryClient.invalidateQueries({
+      queryKey: ["metrics", appName, deploymentName],
+    });
+  };
+
+  return {
+    rows,
+    page,
+    setPage,
+    totalCount,
+    totalPages,
+    isLoading,
+    isError,
+    isFetching,
+    refetch,
+  };
+}

--- a/apps/web/src/pages/history/hooks/useReleaseToggles.ts
+++ b/apps/web/src/pages/history/hooks/useReleaseToggles.ts
@@ -1,0 +1,90 @@
+import { api } from "@/lib/api";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { MergedItem } from "../types";
+
+// disabled/mandatory 토글 액션 (confirm 포함)
+export function useReleaseToggles(appName: string, deploymentName: string) {
+  const queryClient = useQueryClient();
+
+  const invalidateHistory = () => {
+    queryClient.invalidateQueries({
+      queryKey: ["history", appName, deploymentName],
+    });
+  };
+
+  const alertError = (error: unknown) => {
+    const message =
+      (error as { response?: { data?: { message?: string } } })?.response?.data
+        ?.message ?? "릴리즈 업데이트에 실패했습니다.";
+    window.alert(message);
+  };
+
+  const disableMutation = useMutation({
+    mutationFn: async ({
+      label,
+      isDisabled,
+    }: {
+      label: string;
+      isDisabled: boolean;
+    }) =>
+      api.appsAppNameDeploymentsDeploymentNameReleaseDisabledPatch(
+        appName,
+        deploymentName,
+        { label, isDisabled },
+      ),
+    onSuccess: invalidateHistory,
+    onError: alertError,
+  });
+
+  const mandatoryMutation = useMutation({
+    mutationFn: async ({
+      label,
+      isMandatory,
+    }: {
+      label: string;
+      isMandatory: boolean;
+    }) =>
+      api.appsAppNameDeploymentsDeploymentNameReleaseMandatoryPatch(
+        appName,
+        deploymentName,
+        { label, isMandatory },
+      ),
+    onSuccess: invalidateHistory,
+    onError: alertError,
+  });
+
+  const onToggleDisable = (item: MergedItem) => {
+    if (!item.label) return;
+    const willDisable = !item.isDisabled;
+    const confirmed = window.confirm(
+      `Label: ${item.label}\nDescription: ${item.description ?? "-"}\n\n이 버전을 ${
+        willDisable ? "비활성화" : "활성화"
+      }하시겠습니까?`,
+    );
+    if (!confirmed) return;
+    disableMutation.mutate({ label: item.label, isDisabled: willDisable });
+  };
+
+  const onToggleMandatory = (item: MergedItem) => {
+    if (!item.label) return;
+    const willMandatory = !item.isMandatory;
+    const confirmed = window.confirm(
+      `Label: ${item.label}\nDescription: ${item.description ?? "-"}\n\n이 버전을 ${
+        willMandatory ? "Mandatory로 설정" : "Optional로 해제"
+      }하시겠습니까?${
+        willMandatory
+          ? "\n\n⚠️ Mandatory 설정 시 이 버전 이전을 실행 중인 기기들의 다음 업데이트가 강제 업데이트로 승격됩니다."
+          : ""
+      }`,
+    );
+    if (!confirmed) return;
+    mandatoryMutation.mutate({ label: item.label, isMandatory: willMandatory });
+  };
+
+  return {
+    onToggleDisable,
+    onToggleMandatory,
+    isDisablePending: disableMutation.isPending,
+    isMandatoryPending: mandatoryMutation.isPending,
+  };
+}

--- a/apps/web/src/pages/history/types.ts
+++ b/apps/web/src/pages/history/types.ts
@@ -1,0 +1,29 @@
+// history 라우트는 서버 OpenAPI 응답 스키마가 비어 있어 api-client가 void로 생성한다.
+// 실제 응답은 { history, totalCount, page, pageSize } 이므로 여기서 형태를 명시한다.
+export interface ReleaseHistoryItem {
+  label?: string;
+  appVersion?: string;
+  isMandatory?: boolean;
+  isDisabled?: boolean;
+  description?: string;
+  size?: number;
+  rollout?: number | null;
+  releaseMethod?: string;
+  uploadTime?: number;
+}
+
+export interface HistoryResponse {
+  history: ReleaseHistoryItem[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+}
+
+export interface MetricEntry {
+  active?: number;
+  downloads?: number;
+  installed?: number;
+  failed?: number;
+}
+
+export type MergedItem = ReleaseHistoryItem & MetricEntry;

--- a/packages/api-client/src/api.ts
+++ b/packages/api-client/src/api.ts
@@ -298,6 +298,44 @@ export interface AppsAppNameDeploymentsDeploymentNameMetricsGet200ResponseMetric
 /**
  * 
  * @export
+ * @interface AppsAppNameDeploymentsDeploymentNameReleaseDisabledPatchRequest
+ */
+export interface AppsAppNameDeploymentsDeploymentNameReleaseDisabledPatchRequest {
+    /**
+     * 
+     * @type {string}
+     * @memberof AppsAppNameDeploymentsDeploymentNameReleaseDisabledPatchRequest
+     */
+    'label'?: string;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof AppsAppNameDeploymentsDeploymentNameReleaseDisabledPatchRequest
+     */
+    'isDisabled': boolean;
+}
+/**
+ * 
+ * @export
+ * @interface AppsAppNameDeploymentsDeploymentNameReleaseMandatoryPatchRequest
+ */
+export interface AppsAppNameDeploymentsDeploymentNameReleaseMandatoryPatchRequest {
+    /**
+     * 
+     * @type {string}
+     * @memberof AppsAppNameDeploymentsDeploymentNameReleaseMandatoryPatchRequest
+     */
+    'label'?: string;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof AppsAppNameDeploymentsDeploymentNameReleaseMandatoryPatchRequest
+     */
+    'isMandatory': boolean;
+}
+/**
+ * 
+ * @export
  * @interface AppsAppNameDeploymentsDeploymentNameReleasePatchRequest
  */
 export interface AppsAppNameDeploymentsDeploymentNameReleasePatchRequest {
@@ -1910,6 +1948,88 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
             };
         },
         /**
+         * Update release disabled state
+         * @param {string} appName 
+         * @param {string} deploymentName 
+         * @param {AppsAppNameDeploymentsDeploymentNameReleaseDisabledPatchRequest} [appsAppNameDeploymentsDeploymentNameReleaseDisabledPatchRequest] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        appsAppNameDeploymentsDeploymentNameReleaseDisabledPatch: async (appName: string, deploymentName: string, appsAppNameDeploymentsDeploymentNameReleaseDisabledPatchRequest?: AppsAppNameDeploymentsDeploymentNameReleaseDisabledPatchRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'appName' is not null or undefined
+            assertParamExists('appsAppNameDeploymentsDeploymentNameReleaseDisabledPatch', 'appName', appName)
+            // verify required parameter 'deploymentName' is not null or undefined
+            assertParamExists('appsAppNameDeploymentsDeploymentNameReleaseDisabledPatch', 'deploymentName', deploymentName)
+            const localVarPath = `/apps/{appName}/deployments/{deploymentName}/release/disabled`
+                .replace(`{${"appName"}}`, encodeURIComponent(String(appName)))
+                .replace(`{${"deploymentName"}}`, encodeURIComponent(String(deploymentName)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'PATCH', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(appsAppNameDeploymentsDeploymentNameReleaseDisabledPatchRequest, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * Update release mandatory state
+         * @param {string} appName 
+         * @param {string} deploymentName 
+         * @param {AppsAppNameDeploymentsDeploymentNameReleaseMandatoryPatchRequest} [appsAppNameDeploymentsDeploymentNameReleaseMandatoryPatchRequest] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        appsAppNameDeploymentsDeploymentNameReleaseMandatoryPatch: async (appName: string, deploymentName: string, appsAppNameDeploymentsDeploymentNameReleaseMandatoryPatchRequest?: AppsAppNameDeploymentsDeploymentNameReleaseMandatoryPatchRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'appName' is not null or undefined
+            assertParamExists('appsAppNameDeploymentsDeploymentNameReleaseMandatoryPatch', 'appName', appName)
+            // verify required parameter 'deploymentName' is not null or undefined
+            assertParamExists('appsAppNameDeploymentsDeploymentNameReleaseMandatoryPatch', 'deploymentName', deploymentName)
+            const localVarPath = `/apps/{appName}/deployments/{deploymentName}/release/mandatory`
+                .replace(`{${"appName"}}`, encodeURIComponent(String(appName)))
+                .replace(`{${"deploymentName"}}`, encodeURIComponent(String(deploymentName)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'PATCH', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(appsAppNameDeploymentsDeploymentNameReleaseMandatoryPatchRequest, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
          * Update release
          * @param {string} appName 
          * @param {string} deploymentName 
@@ -2910,6 +3030,34 @@ export const DefaultApiFp = function(configuration?: Configuration) {
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
+         * Update release disabled state
+         * @param {string} appName 
+         * @param {string} deploymentName 
+         * @param {AppsAppNameDeploymentsDeploymentNameReleaseDisabledPatchRequest} [appsAppNameDeploymentsDeploymentNameReleaseDisabledPatchRequest] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async appsAppNameDeploymentsDeploymentNameReleaseDisabledPatch(appName: string, deploymentName: string, appsAppNameDeploymentsDeploymentNameReleaseDisabledPatchRequest?: AppsAppNameDeploymentsDeploymentNameReleaseDisabledPatchRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.appsAppNameDeploymentsDeploymentNameReleaseDisabledPatch(appName, deploymentName, appsAppNameDeploymentsDeploymentNameReleaseDisabledPatchRequest, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['DefaultApi.appsAppNameDeploymentsDeploymentNameReleaseDisabledPatch']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * Update release mandatory state
+         * @param {string} appName 
+         * @param {string} deploymentName 
+         * @param {AppsAppNameDeploymentsDeploymentNameReleaseMandatoryPatchRequest} [appsAppNameDeploymentsDeploymentNameReleaseMandatoryPatchRequest] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async appsAppNameDeploymentsDeploymentNameReleaseMandatoryPatch(appName: string, deploymentName: string, appsAppNameDeploymentsDeploymentNameReleaseMandatoryPatchRequest?: AppsAppNameDeploymentsDeploymentNameReleaseMandatoryPatchRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.appsAppNameDeploymentsDeploymentNameReleaseMandatoryPatch(appName, deploymentName, appsAppNameDeploymentsDeploymentNameReleaseMandatoryPatchRequest, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['DefaultApi.appsAppNameDeploymentsDeploymentNameReleaseMandatoryPatch']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
          * Update release
          * @param {string} appName 
          * @param {string} deploymentName 
@@ -3344,6 +3492,28 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
             return localVarFp.appsAppNameDeploymentsDeploymentNamePatch(appName, deploymentName, appsAppNamePatchRequest, options).then((request) => request(axios, basePath));
         },
         /**
+         * Update release disabled state
+         * @param {string} appName 
+         * @param {string} deploymentName 
+         * @param {AppsAppNameDeploymentsDeploymentNameReleaseDisabledPatchRequest} [appsAppNameDeploymentsDeploymentNameReleaseDisabledPatchRequest] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        appsAppNameDeploymentsDeploymentNameReleaseDisabledPatch(appName: string, deploymentName: string, appsAppNameDeploymentsDeploymentNameReleaseDisabledPatchRequest?: AppsAppNameDeploymentsDeploymentNameReleaseDisabledPatchRequest, options?: RawAxiosRequestConfig): AxiosPromise<void> {
+            return localVarFp.appsAppNameDeploymentsDeploymentNameReleaseDisabledPatch(appName, deploymentName, appsAppNameDeploymentsDeploymentNameReleaseDisabledPatchRequest, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * Update release mandatory state
+         * @param {string} appName 
+         * @param {string} deploymentName 
+         * @param {AppsAppNameDeploymentsDeploymentNameReleaseMandatoryPatchRequest} [appsAppNameDeploymentsDeploymentNameReleaseMandatoryPatchRequest] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        appsAppNameDeploymentsDeploymentNameReleaseMandatoryPatch(appName: string, deploymentName: string, appsAppNameDeploymentsDeploymentNameReleaseMandatoryPatchRequest?: AppsAppNameDeploymentsDeploymentNameReleaseMandatoryPatchRequest, options?: RawAxiosRequestConfig): AxiosPromise<void> {
+            return localVarFp.appsAppNameDeploymentsDeploymentNameReleaseMandatoryPatch(appName, deploymentName, appsAppNameDeploymentsDeploymentNameReleaseMandatoryPatchRequest, options).then((request) => request(axios, basePath));
+        },
+        /**
          * Update release
          * @param {string} appName 
          * @param {string} deploymentName 
@@ -3715,6 +3885,28 @@ export interface DefaultApiInterface {
      * @memberof DefaultApiInterface
      */
     appsAppNameDeploymentsDeploymentNamePatch(appName: string, deploymentName: string, appsAppNamePatchRequest?: AppsAppNamePatchRequest, options?: RawAxiosRequestConfig): AxiosPromise<AppsAppNameDeploymentsPost201Response>;
+
+    /**
+     * Update release disabled state
+     * @param {string} appName 
+     * @param {string} deploymentName 
+     * @param {AppsAppNameDeploymentsDeploymentNameReleaseDisabledPatchRequest} [appsAppNameDeploymentsDeploymentNameReleaseDisabledPatchRequest] 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DefaultApiInterface
+     */
+    appsAppNameDeploymentsDeploymentNameReleaseDisabledPatch(appName: string, deploymentName: string, appsAppNameDeploymentsDeploymentNameReleaseDisabledPatchRequest?: AppsAppNameDeploymentsDeploymentNameReleaseDisabledPatchRequest, options?: RawAxiosRequestConfig): AxiosPromise<void>;
+
+    /**
+     * Update release mandatory state
+     * @param {string} appName 
+     * @param {string} deploymentName 
+     * @param {AppsAppNameDeploymentsDeploymentNameReleaseMandatoryPatchRequest} [appsAppNameDeploymentsDeploymentNameReleaseMandatoryPatchRequest] 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DefaultApiInterface
+     */
+    appsAppNameDeploymentsDeploymentNameReleaseMandatoryPatch(appName: string, deploymentName: string, appsAppNameDeploymentsDeploymentNameReleaseMandatoryPatchRequest?: AppsAppNameDeploymentsDeploymentNameReleaseMandatoryPatchRequest, options?: RawAxiosRequestConfig): AxiosPromise<void>;
 
     /**
      * Update release
@@ -4121,6 +4313,32 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
      */
     public appsAppNameDeploymentsDeploymentNamePatch(appName: string, deploymentName: string, appsAppNamePatchRequest?: AppsAppNamePatchRequest, options?: RawAxiosRequestConfig) {
         return DefaultApiFp(this.configuration).appsAppNameDeploymentsDeploymentNamePatch(appName, deploymentName, appsAppNamePatchRequest, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Update release disabled state
+     * @param {string} appName 
+     * @param {string} deploymentName 
+     * @param {AppsAppNameDeploymentsDeploymentNameReleaseDisabledPatchRequest} [appsAppNameDeploymentsDeploymentNameReleaseDisabledPatchRequest] 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DefaultApi
+     */
+    public appsAppNameDeploymentsDeploymentNameReleaseDisabledPatch(appName: string, deploymentName: string, appsAppNameDeploymentsDeploymentNameReleaseDisabledPatchRequest?: AppsAppNameDeploymentsDeploymentNameReleaseDisabledPatchRequest, options?: RawAxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).appsAppNameDeploymentsDeploymentNameReleaseDisabledPatch(appName, deploymentName, appsAppNameDeploymentsDeploymentNameReleaseDisabledPatchRequest, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Update release mandatory state
+     * @param {string} appName 
+     * @param {string} deploymentName 
+     * @param {AppsAppNameDeploymentsDeploymentNameReleaseMandatoryPatchRequest} [appsAppNameDeploymentsDeploymentNameReleaseMandatoryPatchRequest] 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DefaultApi
+     */
+    public appsAppNameDeploymentsDeploymentNameReleaseMandatoryPatch(appName: string, deploymentName: string, appsAppNameDeploymentsDeploymentNameReleaseMandatoryPatchRequest?: AppsAppNameDeploymentsDeploymentNameReleaseMandatoryPatchRequest, options?: RawAxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).appsAppNameDeploymentsDeploymentNameReleaseMandatoryPatch(appName, deploymentName, appsAppNameDeploymentsDeploymentNameReleaseMandatoryPatchRequest, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**


### PR DESCRIPTION
# 요약
> 릴리즈 메타데이터 수정을 disabled/mandatory 전용 엔드포인트 2개로 분리하고, 웹에서 Mandatory 토글을 지원한다. Slack 알림도 두 액션 모두 발사하며 이모지를 단순화한다.

- PRD: 없음
- Figma: 없음

## 배경
- 오리지널 CodePush는 `patch -m`으로 mandatory 변경이 가능했으나, 이 재구현 서버는 `PackageInfoUpdateSchema`에 `isMandatory`가 없고 `updatePackage`도 UPDATE하지 않아 **200 응답을 주면서 조용히 무시**하는 상태.
- 웹은 Disable/Enable만 가능하고 Mandatory는 배지 표시만 있어, 배포 후 강제 업데이트 전환이 불가능했다.

## 변경 사항

- **`management.ts`** — disabled/mandatory 전용 PATCH 엔드포인트 2개 신설
  - Before: PATCH `/release` 하나로 appVersion/description/isDisabled만 수정 가능, isMandatory는 침묵 무시
  - After: `/release/disabled` `{label?, isDisabled}` / `/release/mandatory` `{label?, isMandatory}`로 각 상태를 따로 관리
  - 세부:
    - label 생략 시 최신 릴리즈 대상 (기존 update와 동일 규칙)
    - 권한: Collaborator (기존과 동일 게이트: 401 → 404 → 403)
    - 기존 PATCH `/release`는 CLI(`code-push-standalone patch`) 호환을 위해 그대로 유지
    - 각 핸들러가 Slack 알림 발사 (disabled → Disabled/Enabled, mandatory → MandatoryOn/Off)

- **`d1.ts` / `storage.ts`** — `updatePackageMetadata` 부분 UPDATE 신설
  - Before: `updatePackage`가 캐시에서 읽은 release의 여러 필드를 통째 SET
  - After: 신규 핸들러는 대상 컬럼만 UPDATE (deploymentId+label+deletedAt 스코프)
  - 세부:
    - 히스토리 캐시가 **isolate별 메모리**(TTL 5분)라, stale 캐시 기반 전체 SET은 다른 isolate가 방금 바꾼 필드를 되돌릴 수 있음(lost update — 예: 긴급 disable 직후 다른 isolate에서 mandatory 토글 시 disable 풀림) → 부분 UPDATE로 원천 차단
    - 쓰기 후 캐시 무효화는 기존과 동일

- **`slack.ts`** — 액션 종류 재구성 + 업로드 실패 알림 추가
  - Before: Uploaded/Enabled/Disabled 3종, 헤더에 큰 원형 이모지 🟢/🔴, 업로드 실패 시 알림 없음
  - After: 종류별 4종 — Uploaded(🚀) / UploadFailed(🚨) / Disabled(🧊) / Mandatory(🔥)
  - 세부:
    - on/off는 헤더 텍스트가 `Disabled true/false`, `Mandatory true/false`로 표현 (이모지는 종류 구분만)
    - release.create의 업로드 파이프라인(롤아웃 미완 409/중복 번들 409/R2·D1 오류)을 try-catch로 감싸 실패 시 UploadFailed 알림 발사, 에러 메시지를 본문 코드 블록으로 첨부 (인증·권한 실패는 대상 아님)

- **`HistoryPage.tsx`(web)** — Mandatory 토글 + 버튼 단순화
  - Before: 카드마다 빨간 filled(destructive) Disable 버튼, Mandatory는 배지 표시만
  - After: Mandatory/Optional + Enable/Disable 버튼 2개를 무채색 outline으로 통일
  - 세부:
    - `disableMutation`을 신규 `/release/disabled`로 교체, `mandatoryMutation` 신설
    - Mandatory ON confirm에 강제 업데이트 승격 경고 명시 (updateCheck의 mandatory 승격 로직 파급 고지)

- **`api-client`** — `pnpm generate` 재생성 (신규 메서드 2개)

## 테스트
- [x] 로컬 실서버(677개 릴리즈) E2E: mandatory ON/OFF·disabled ON/OFF → DB 반영 + 캐시 무효화 확인
- [x] 부분 UPDATE 검증 — disabled 토글이 mandatory 값을 건드리지 않음
- [x] label 생략 시 최신 릴리즈 대상 / 미인증 401 / 기존 PATCH `/release` 200 불변
- [x] tsc·biome ci·vitest 117/117 (server), tsc·build (web)
> 테스트 후 로컬 DB 상태 원상복구 완료.

## 참고
- 캐싱·위험성 분석 전체는 Jira 참조: https://yplabs.atlassian.net/browse/FE-67
- 기존 PATCH `/release`(CLI 경로)에는 전체 필드 SET 패턴이 남아 있음 — pre-existing이며 범위 밖 (별도 트랙 후보)
- DB 마이그레이션 불필요 (`is_mandatory` 컬럼 기존재)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
